### PR TITLE
check for filter in images

### DIFF
--- a/python/lsst/meas/extensions/ngmix/mbobs_extractor.py
+++ b/python/lsst/meas/extensions/ngmix/mbobs_extractor.py
@@ -322,10 +322,6 @@ class MBObsExtractor(object):
                 assert xy0 == imf.getXY0(),\
                         "all images must have same reference position"
 
-        if set(self.images.keys()) != set(self.config['filters']):
-            raise RuntimeError("One or more filters missing.")
-
-
 
 def _project_box(source, wcs, radius):
     """

--- a/python/lsst/meas/extensions/ngmix/mbobs_extractor.py
+++ b/python/lsst/meas/extensions/ngmix/mbobs_extractor.py
@@ -312,6 +312,9 @@ class MBObsExtractor(object):
         """
         xy0=None
         for filt in self.config['filters']:
+            if filt not in self.images:
+                raise MBObsMissingDataError('band missing: %s' % filt)
+
             imf = self.images[filt]
             if xy0 is None:
                 xy0 = imf.getXY0()


### PR DESCRIPTION
add a check that the filter is in `self.images`

If not raise `MBObsMissingDataError` which sets a flag down the line