### PR TITLE
DM-20782: Flake8 cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_build.*
 .sconf_temp
 .sconsign.dblite
 *.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: python
+matrix:
+  include:
+    - python: '3.6'
+      install:
+      - pip install flake8
+      script: flake8

--- a/SConstruct
+++ b/SConstruct
@@ -1,3 +1,3 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConstruct("meas_extensions_ngmix")
+scripts.BasicSConstruct("meas_extensions_ngmix", disableCc=True)

--- a/example_config/ngmix-bd.py
+++ b/example_config/ngmix-bd.py
@@ -13,7 +13,7 @@ config.useDeblends = False
 # write out some diagnostic plots to the CWD, defaults to False
 #config.make_plots: False
 # a prefix to add to plot names
-#config.plot_prefix='./plots/'
+# config.plot_prefix='./plots/'
 
 #
 # postage stamp config
@@ -26,7 +26,7 @@ config.stamps.sigma_factor = 5.0
 
 # Jim comments "bright object" is just a geometric region around bright stars,
 # intended mostly for people doing things like cross-correlations that could be
-# impacted by e.g.  slight systematic effects in the background.  
+# impacted by e.g.  slight systematic effects in the background.
 #
 # "clipped" means one or more input images was not used in this area (for large
 # regions that's usually because of a ghost, I think) - but the PSF model acts
@@ -53,12 +53,12 @@ config.stamps.bits_to_ignore_for_weight = [
     'EDGE',
     'SUSPECT',
     'NO_DATA',
-    #'BRIGHT_OBJECT',
+    # 'BRIGHT_OBJECT',
     # only appears in coadd, may want to cut on this for shear
-    #'CLIPPED',
+    # 'CLIPPED',
     'CROSSTALK',
     # only matter if we are using the deblended photometry, which we are not here
-    #'NOT_DEBLENDED',
+    # 'NOT_DEBLENDED',
     'UNMASKEDNAN',
 ]
 
@@ -68,22 +68,22 @@ config.stamps.bits_to_ignore_for_weight = [
 # in 10 year LSST might not matter as much (except for NO_DATA)
 config.stamps.bits_to_null = [
     # for coadd assume OK since will be interpolated on one of the epochs
-    #'BAD',
+    # 'BAD',
     'SAT',
     # Jim says "cut on the reason it was interpolated rather than this"
-    #'INTRP',
+    # 'INTRP',
     # for coadd assume OK since will be interpolated on one of the epochs
-    #'CR',
+    # 'CR',
     'EDGE',
     'SUSPECT',
     'NO_DATA',
     # Jim suggests we cut these after the fact in the bright star mask
-    #'BRIGHT_OBJECT',
+    # 'BRIGHT_OBJECT',
     # only appears in coadd, may want to cut on this for shear
-    #'CLIPPED',
-    #'CROSSTALK',
+    # 'CLIPPED',
+    # 'CROSSTALK',
     # only matter if we are using the deblended photometry, which we are not here
-    #'NOT_DEBLENDED',
+    # 'NOT_DEBLENDED',
     'UNMASKEDNAN',
 ]
 
@@ -95,76 +95,74 @@ config.stamps.bits_to_null = [
 config.stamps.max_zero_weight_frac = 0.45
 
 
-
 ###############
 # object config
 
-config.obj.model="bd"
+config.obj.model = "bd"
 
 #
 # prior on center
 #
 
-config.obj.priors.cen.type="gauss2d"
+config.obj.priors.cen.type = "gauss2d"
 
 # this is the width in both directions
-config.obj.priors.cen.pars=[0.2]
+config.obj.priors.cen.pars = [0.2]
 
 #
 # prior on the ellipticity g
 #
 
-config.obj.priors.g.type="ba"
+config.obj.priors.g.type = "ba"
 
 # this is the width
-config.obj.priors.g.pars=[0.3]
+config.obj.priors.g.pars = [0.3]
 
 
 #
 # prior on the size squared T
 #
 
-config.obj.priors.T.type="two-sided-erf"
+config.obj.priors.T.type = "two-sided-erf"
 
 # this is the width
-config.obj.priors.T.pars=[-10.0, 0.03, 1.0e+06, 1.0e+05]
+config.obj.priors.T.pars = [-10.0, 0.03, 1.0e+06, 1.0e+05]
 
 #
 # prior on fracdev, only used if model is "bd"
 #
 
-config.obj.priors.fracdev.type="gauss"
+config.obj.priors.fracdev.type = "gauss"
 
 # this is the center and sigma of the gaussian
-config.obj.priors.fracdev.pars=[0.5, 0.1]
+config.obj.priors.fracdev.pars = [0.5, 0.1]
 
 
 #
 # prior on the flux
 #
 
-config.obj.priors.flux.type="two-sided-erf"
+config.obj.priors.flux.type = "two-sided-erf"
 
 # this is the width
-config.obj.priors.flux.pars=[-1.0e+04, 1.0, 1.0e+09, 0.25e+08]
+config.obj.priors.flux.pars = [-1.0e+04, 1.0, 1.0e+09, 0.25e+08]
 
 # fitting parameters
-config.obj.max_pars.ntry=2
-config.obj.max_pars.lm_pars.maxfev=2000
-config.obj.max_pars.lm_pars.xtol=5.0e-5
-config.obj.max_pars.lm_pars.ftol=5.0e-5
+config.obj.max_pars.ntry = 2
+config.obj.max_pars.lm_pars.maxfev = 2000
+config.obj.max_pars.lm_pars.xtol = 5.0e-5
+config.obj.max_pars.lm_pars.ftol = 5.0e-5
 
 
 #############
 # psf config
 
 # 3 cocentric, coelliptical gaussians
-config.psf.model="coellip3"
-config.psf.fwhm_guess=0.8
+config.psf.model = "coellip3"
+config.psf.fwhm_guess = 0.8
 
 # fitting parameters
-config.psf.max_pars.ntry=4
-config.psf.max_pars.lm_pars.maxfev=2000
-config.psf.max_pars.lm_pars.xtol=5.0e-5
-config.psf.max_pars.lm_pars.ftol=5.0e-5
-
+config.psf.max_pars.ntry = 4
+config.psf.max_pars.lm_pars.maxfev = 2000
+config.psf.max_pars.lm_pars.xtol = 5.0e-5
+config.psf.max_pars.lm_pars.ftol = 5.0e-5

--- a/example_config/ngmix-deblended-bd.py
+++ b/example_config/ngmix-deblended-bd.py
@@ -13,7 +13,7 @@
 # write out some diagnostic plots to the CWD, defaults to False
 #config.make_plots: False
 # a prefix to add to plot names
-#config.plot_prefix='./plots/'
+# config.plot_prefix='./plots/'
 
 #
 # postage stamp config
@@ -26,7 +26,7 @@ config.stamps.sigma_factor = 5.0
 
 # Jim comments "bright object" is just a geometric region around bright stars,
 # intended mostly for people doing things like cross-correlations that could be
-# impacted by e.g.  slight systematic effects in the background.  
+# impacted by e.g.  slight systematic effects in the background.
 #
 # "clipped" means one or more input images was not used in this area (for large
 # regions that's usually because of a ghost, I think) - but the PSF model acts
@@ -52,9 +52,9 @@ config.stamps.bits_to_ignore_for_weight = [
     'EDGE',
     'SUSPECT',
     'NO_DATA',
-    #'BRIGHT_OBJECT',
+    # 'BRIGHT_OBJECT',
     # only appears in coadd, may want to cut on this for shear
-    #'CLIPPED',
+    # 'CLIPPED',
     'CROSSTALK',
     # only matter if we are using the deblended photometry, which we are not here
     'NOT_DEBLENDED',
@@ -66,22 +66,22 @@ config.stamps.bits_to_ignore_for_weight = [
 # for metacal here
 config.stamps.bits_to_null = [
     # for coadd assume OK since will be interpolated on one of the epochs
-    #'BAD',
+    # 'BAD',
     'SAT',
     # Jim says "cut on the reason it was interpolated rather than this"
-    #'INTRP',
+    # 'INTRP',
     # for coadd assume OK since will be interpolated on one of the epochs
-    #'CR',
+    # 'CR',
     'EDGE',
     'SUSPECT',
     'NO_DATA',
     # Jim suggests we cut these after the fact in the bright star mask
-    #'BRIGHT_OBJECT',
+    # 'BRIGHT_OBJECT',
     # only appears in coadd, may want to cut on this for shear
-    #'CLIPPED',
-    #'CROSSTALK',
+    # 'CLIPPED',
+    # 'CROSSTALK',
     # only matter if we are using the deblended photometry, which we are not here
-    #'NOT_DEBLENDED',
+    # 'NOT_DEBLENDED',
     'UNMASKEDNAN',
 ]
 
@@ -96,72 +96,71 @@ config.stamps.max_zero_weight_frac = 0.45
 ###############
 # object config
 
-config.obj.model="bd"
+config.obj.model = "bd"
 
 #
 # prior on center
 #
 
-config.obj.priors.cen.type="gauss2d"
+config.obj.priors.cen.type = "gauss2d"
 
 # this is the width in both directions
-config.obj.priors.cen.pars=[0.2]
+config.obj.priors.cen.pars = [0.2]
 
 #
 # prior on the ellipticity g
 #
 
-config.obj.priors.g.type="ba"
+config.obj.priors.g.type = "ba"
 
 # this is the width
-config.obj.priors.g.pars=[0.3]
+config.obj.priors.g.pars = [0.3]
 
 
 #
 # prior on the size squared T
 #
 
-config.obj.priors.T.type="two-sided-erf"
+config.obj.priors.T.type = "two-sided-erf"
 
 # this is the width
-config.obj.priors.T.pars=[-10.0, 0.03, 1.0e+06, 1.0e+05]
+config.obj.priors.T.pars = [-10.0, 0.03, 1.0e+06, 1.0e+05]
 
 #
 # prior on fracdev, only used if model is "bd"
 #
 
-config.obj.priors.fracdev.type="gauss"
+config.obj.priors.fracdev.type = "gauss"
 
 # this is the center and sigma of the gaussian
-config.obj.priors.fracdev.pars=[0.5, 0.1]
+config.obj.priors.fracdev.pars = [0.5, 0.1]
 
 
 #
 # prior on the flux
 #
 
-config.obj.priors.flux.type="two-sided-erf"
+config.obj.priors.flux.type = "two-sided-erf"
 
 # this is the width
-config.obj.priors.flux.pars=[-1.0e+04, 1.0, 1.0e+09, 0.25e+08]
+config.obj.priors.flux.pars = [-1.0e+04, 1.0, 1.0e+09, 0.25e+08]
 
 # fitting parameters
-config.obj.max_pars.ntry=2
-config.obj.max_pars.lm_pars.maxfev=2000
-config.obj.max_pars.lm_pars.xtol=5.0e-5
-config.obj.max_pars.lm_pars.ftol=5.0e-5
+config.obj.max_pars.ntry = 2
+config.obj.max_pars.lm_pars.maxfev = 2000
+config.obj.max_pars.lm_pars.xtol = 5.0e-5
+config.obj.max_pars.lm_pars.ftol = 5.0e-5
 
 
 #############
 # psf config
 
 # 3 cocentric, coelliptical gaussians
-config.psf.model="coellip3"
-config.psf.fwhm_guess=0.8
+config.psf.model = "coellip3"
+config.psf.fwhm_guess = 0.8
 
 # fitting parameters
-config.psf.max_pars.ntry=4
-config.psf.max_pars.lm_pars.maxfev=2000
-config.psf.max_pars.lm_pars.xtol=5.0e-5
-config.psf.max_pars.lm_pars.ftol=5.0e-5
-
+config.psf.max_pars.ntry = 4
+config.psf.max_pars.lm_pars.maxfev = 2000
+config.psf.max_pars.lm_pars.xtol = 5.0e-5
+config.psf.max_pars.lm_pars.ftol = 5.0e-5

--- a/example_config/ngmix-deblended-mcalmax.py
+++ b/example_config/ngmix-deblended-mcalmax.py
@@ -20,7 +20,7 @@
 # write out some diagnostic plots to the CWD, defaults to False
 #config.make_plots: False
 # a prefix to add to plot names
-#config.plot_prefix='./plots/'
+# config.plot_prefix='./plots/'
 
 #
 # postage stamp config
@@ -33,7 +33,7 @@ config.stamps.sigma_factor = 5.0
 
 # Jim comments "bright object" is just a geometric region around bright stars,
 # intended mostly for people doing things like cross-correlations that could be
-# impacted by e.g.  slight systematic effects in the background.  
+# impacted by e.g.  slight systematic effects in the background.
 #
 # "clipped" means one or more input images was not used in this area (for large
 # regions that's usually because of a ghost, I think) - but the PSF model acts
@@ -59,12 +59,12 @@ config.stamps.bits_to_ignore_for_weight = [
     'EDGE',
     'SUSPECT',
     'NO_DATA',
-    #'BRIGHT_OBJECT',
+    # 'BRIGHT_OBJECT',
     # only appears in coadd, may want to cut on this for shear
-    #'CLIPPED',
+    # 'CLIPPED',
     'CROSSTALK',
     # only matter if we are using the deblended photometry, which we are not here
-    #'NOT_DEBLENDED',
+    # 'NOT_DEBLENDED',
     'UNMASKEDNAN',
 ]
 
@@ -73,22 +73,22 @@ config.stamps.bits_to_ignore_for_weight = [
 # for metacal here
 config.stamps.bits_to_null = [
     # for coadd assume OK since will be interpolated on one of the epochs
-    #'BAD',
+    # 'BAD',
     'SAT',
     # Jim says "cut on the reason it was interpolated rather than this"
-    #'INTRP',
+    # 'INTRP',
     # for coadd assume OK since will be interpolated on one of the epochs
-    #'CR',
+    # 'CR',
     'EDGE',
     'SUSPECT',
     'NO_DATA',
     # Jim suggests we cut these after the fact in the bright star mask
-    #'BRIGHT_OBJECT',
+    # 'BRIGHT_OBJECT',
     # only appears in coadd, may want to cut on this for shear
-    #'CLIPPED',
-    #'CROSSTALK',
+    # 'CLIPPED',
+    # 'CROSSTALK',
     # only matter if we are using the deblended photometry, which we are not here
-    #'NOT_DEBLENDED',
+    # 'NOT_DEBLENDED',
     'UNMASKEDNAN',
 ]
 
@@ -98,7 +98,7 @@ config.stamps.bits_to_null = [
 config.stamps.bits_to_cut = [
     'BRIGHT_OBJECT',
     'INEXACT_PSF',
-    #'NOT_DEBLENDED',
+    # 'NOT_DEBLENDED',
 ]
 
 # we will be nulling the weight map for some bits, don't allow more
@@ -108,66 +108,66 @@ config.stamps.max_zero_weight_frac = 0.05
 ###############
 # object config
 
-config.obj.model="gauss"
+config.obj.model = "gauss"
 
 #
 # prior on center
 #
 
-config.obj.priors.cen.type="gauss2d"
+config.obj.priors.cen.type = "gauss2d"
 
 # this is the width in both directions
-config.obj.priors.cen.pars=[0.2]
+config.obj.priors.cen.pars = [0.2]
 
 #
 # prior on the ellipticity g
 #
 
-config.obj.priors.g.type="ba"
+config.obj.priors.g.type = "ba"
 
 # this is the width
-config.obj.priors.g.pars=[0.3]
+config.obj.priors.g.pars = [0.3]
 
 
 #
 # prior on the size squared T
 #
 
-config.obj.priors.T.type="two-sided-erf"
+config.obj.priors.T.type = "two-sided-erf"
 
 # this is the width
-config.obj.priors.T.pars=[-10.0, 0.03, 1.0e+06, 1.0e+05]
+config.obj.priors.T.pars = [-10.0, 0.03, 1.0e+06, 1.0e+05]
 
 
 #
 # prior on the flux
 #
 
-config.obj.priors.flux.type="two-sided-erf"
+config.obj.priors.flux.type = "two-sided-erf"
 
 # this is the width
-config.obj.priors.flux.pars=[-1.0e+04, 1.0, 1.0e+09, 0.25e+08]
+config.obj.priors.flux.pars = [-1.0e+04, 1.0, 1.0e+09, 0.25e+08]
 
 # fitting parameters
-config.obj.max_pars.ntry=2
-config.obj.max_pars.lm_pars.maxfev=2000
-config.obj.max_pars.lm_pars.xtol=5.0e-5
-config.obj.max_pars.lm_pars.ftol=5.0e-5
+config.obj.max_pars.ntry = 2
+config.obj.max_pars.lm_pars.maxfev = 2000
+config.obj.max_pars.lm_pars.xtol = 5.0e-5
+config.obj.max_pars.lm_pars.ftol = 5.0e-5
 
 
 #############
 # psf config
 
 # a single gaussian
-config.psf.model="gauss"
-config.psf.fwhm_guess=0.8
+config.psf.model = "gauss"
+config.psf.fwhm_guess = 0.8
 
 # fitting parameters
-config.psf.max_pars.ntry=4
-config.psf.max_pars.lm_pars.maxfev=2000
-config.psf.max_pars.lm_pars.xtol=5.0e-5
-config.psf.max_pars.lm_pars.ftol=5.0e-5
+config.psf.max_pars.ntry = 4
+config.psf.max_pars.lm_pars.maxfev = 2000
+config.psf.max_pars.lm_pars.xtol = 5.0e-5
+config.psf.max_pars.lm_pars.ftol = 5.0e-5
 
 # metacal pars (using the default)
-#config.metacal.psf='fitgauss'
-#config.metacal.types=['noshear','1p','1m','2p','2m']
+# config.metacal.psf='fitgauss'
+# config.metacal.types=['noshear','1p','1m','2p','2m']

--- a/example_config/ngmix-mcalmax.py
+++ b/example_config/ngmix-mcalmax.py
@@ -13,7 +13,7 @@ config.useDeblends = False
 # write out some diagnostic plots to the CWD, defaults to False
 #config.make_plots: False
 # a prefix to add to plot names
-#config.plot_prefix='./plots/'
+# config.plot_prefix='./plots/'
 
 #
 # postage stamp config
@@ -26,7 +26,7 @@ config.stamps.sigma_factor = 5.0
 
 # Jim comments "bright object" is just a geometric region around bright stars,
 # intended mostly for people doing things like cross-correlations that could be
-# impacted by e.g.  slight systematic effects in the background.  
+# impacted by e.g.  slight systematic effects in the background.
 #
 # "clipped" means one or more input images was not used in this area (for large
 # regions that's usually because of a ghost, I think) - but the PSF model acts
@@ -52,12 +52,12 @@ config.stamps.bits_to_ignore_for_weight = [
     'EDGE',
     'SUSPECT',
     'NO_DATA',
-    #'BRIGHT_OBJECT',
+    # 'BRIGHT_OBJECT',
     # only appears in coadd, may want to cut on this for shear
-    #'CLIPPED',
+    # 'CLIPPED',
     'CROSSTALK',
     # only matter if we are using the deblended photometry, which we are not here
-    #'NOT_DEBLENDED',
+    # 'NOT_DEBLENDED',
     'UNMASKEDNAN',
 ]
 
@@ -66,22 +66,22 @@ config.stamps.bits_to_ignore_for_weight = [
 # for metacal here
 config.stamps.bits_to_null = [
     # for coadd assume OK since will be interpolated on one of the epochs
-    #'BAD',
+    # 'BAD',
     'SAT',
     # Jim says "cut on the reason it was interpolated rather than this"
-    #'INTRP',
+    # 'INTRP',
     # for coadd assume OK since will be interpolated on one of the epochs
-    #'CR',
+    # 'CR',
     'EDGE',
     'SUSPECT',
     'NO_DATA',
     # Jim suggests we cut these after the fact in the bright star mask
-    #'BRIGHT_OBJECT',
+    # 'BRIGHT_OBJECT',
     # only appears in coadd, may want to cut on this for shear
-    #'CLIPPED',
-    #'CROSSTALK',
+    # 'CLIPPED',
+    # 'CROSSTALK',
     # only matter if we are using the deblended photometry, which we are not here
-    #'NOT_DEBLENDED',
+    # 'NOT_DEBLENDED',
     'UNMASKEDNAN',
 ]
 
@@ -98,66 +98,66 @@ config.stamps.max_zero_weight_frac = 0.05
 ###############
 # object config
 
-config.obj.model="gauss"
+config.obj.model = "gauss"
 
 #
 # prior on center
 #
 
-config.obj.priors.cen.type="gauss2d"
+config.obj.priors.cen.type = "gauss2d"
 
 # this is the width in both directions
-config.obj.priors.cen.pars=[0.2]
+config.obj.priors.cen.pars = [0.2]
 
 #
 # prior on the ellipticity g
 #
 
-config.obj.priors.g.type="ba"
+config.obj.priors.g.type = "ba"
 
 # this is the width
-config.obj.priors.g.pars=[0.3]
+config.obj.priors.g.pars = [0.3]
 
 
 #
 # prior on the size squared T
 #
 
-config.obj.priors.T.type="two-sided-erf"
+config.obj.priors.T.type = "two-sided-erf"
 
 # this is the width
-config.obj.priors.T.pars=[-10.0, 0.03, 1.0e+06, 1.0e+05]
+config.obj.priors.T.pars = [-10.0, 0.03, 1.0e+06, 1.0e+05]
 
 
 #
 # prior on the flux
 #
 
-config.obj.priors.flux.type="two-sided-erf"
+config.obj.priors.flux.type = "two-sided-erf"
 
 # this is the width
-config.obj.priors.flux.pars=[-1.0e+04, 1.0, 1.0e+09, 0.25e+08]
+config.obj.priors.flux.pars = [-1.0e+04, 1.0, 1.0e+09, 0.25e+08]
 
 # fitting parameters
-config.obj.max_pars.ntry=2
-config.obj.max_pars.lm_pars.maxfev=2000
-config.obj.max_pars.lm_pars.xtol=5.0e-5
-config.obj.max_pars.lm_pars.ftol=5.0e-5
+config.obj.max_pars.ntry = 2
+config.obj.max_pars.lm_pars.maxfev = 2000
+config.obj.max_pars.lm_pars.xtol = 5.0e-5
+config.obj.max_pars.lm_pars.ftol = 5.0e-5
 
 
 #############
 # psf config
 
 # a single gaussian
-config.psf.model="gauss"
-config.psf.fwhm_guess=0.8
+config.psf.model = "gauss"
+config.psf.fwhm_guess = 0.8
 
 # fitting parameters
-config.psf.max_pars.ntry=4
-config.psf.max_pars.lm_pars.maxfev=2000
-config.psf.max_pars.lm_pars.xtol=5.0e-5
-config.psf.max_pars.lm_pars.ftol=5.0e-5
+config.psf.max_pars.ntry = 4
+config.psf.max_pars.lm_pars.maxfev = 2000
+config.psf.max_pars.lm_pars.xtol = 5.0e-5
+config.psf.max_pars.lm_pars.ftol = 5.0e-5
 
 # metacal pars (using the default)
-#config.metacal.psf='fitgauss'
-#config.metacal.types=['noshear','1p','1m','2p','2m']
+# config.metacal.psf='fitgauss'
+# config.metacal.types=['noshear','1p','1m','2p','2m']

--- a/python/lsst/meas/extensions/ngmix/EMPsfApprox.py
+++ b/python/lsst/meas/extensions/ngmix/EMPsfApprox.py
@@ -59,9 +59,11 @@ class SingleFrameEmPsfApproxConfig(SingleFramePluginConfig):
 @register("ngmix_EMPsfApprox")
 class SingleFrameEmPsfApproxPlugin(SingleFramePlugin):
     """
-    Plugin to do Psf modeling using the ngmix Expectation-Maximization Algorithm.
+    Plugin to do Psf modeling using the ngmix Expectation-Maximization
+    Algorithm.
     Calls the ngmix fitter ngmix.EMRunner with an image of the Psf.
-    Returns nGauss Gaussians stored as lsst.shapelet.ShapeletFunction components.
+    Returns nGauss Gaussians stored as lsst.shapelet.ShapeletFunction
+    components.
     """
     ConfigClass = SingleFrameEmPsfApproxConfig
 

--- a/python/lsst/meas/extensions/ngmix/bootstrap.py
+++ b/python/lsst/meas/extensions/ngmix/bootstrap.py
@@ -414,6 +414,8 @@ class MetacalMaxBootstrapper(object):
         if boot.result['psf']['flags'] != 0:
             logger.debug('cannot do symmetrize psf due to psf fitting failures')
             # TODO need finer grained flag
+            raise RuntimeError("Code path not supported")
+            res = dict()
             res['mcal_flags'] = procflags.METACAL_PSF_FAILURE
             return res
 

--- a/python/lsst/meas/extensions/ngmix/bootstrap.py
+++ b/python/lsst/meas/extensions/ngmix/bootstrap.py
@@ -8,7 +8,6 @@ Also we don't plan to support multi-epoch fitting so these can be simplified
 import lsst.log
 import numpy as np
 import ngmix
-from ngmix.gexceptions import GMixRangeError, BootPSFFailure, BootGalFailure
 from . import procflags
 
 from copy import deepcopy

--- a/python/lsst/meas/extensions/ngmix/bootstrap.py
+++ b/python/lsst/meas/extensions/ngmix/bootstrap.py
@@ -13,27 +13,27 @@ from . import procflags
 
 from copy import deepcopy
 
-logger=lsst.log.Log.getLogger("meas.extensions.ngmix.bootstrap")
+logger = lsst.log.Log.getLogger("meas.extensions.ngmix.bootstrap")
 
 DEFAULT_RESULT = {
     # overall processing flags
-    'flags':procflags.NO_ATTEMPT,
+    'flags': procflags.NO_ATTEMPT,
 
     # psf fitting related information
-    'psf':{
-        'flags':procflags.NO_ATTEMPT,
-        'byband':[],
+    'psf': {
+        'flags': procflags.NO_ATTEMPT,
+        'byband': [],
     },
 
     # psf flux fitting related information
-    'psf_flux':{
-        'flags':procflags.NO_ATTEMPT,
-        'byband':[],
+    'psf_flux': {
+        'flags': procflags.NO_ATTEMPT,
+        'byband': [],
     },
 
     # object fitting related information
     'obj': {
-        'flags':procflags.NO_ATTEMPT,
+        'flags': procflags.NO_ATTEMPT,
     }
 }
 
@@ -50,11 +50,13 @@ for type in DEFAULT_MCAL_RESULT:
     if type not in['mcal_flags']:
         DEFAULT_MCAL_RESULT[type] = deepcopy(DEFAULT_RESULT)
 
+
 def get_default_result():
     """
     get the default result dict for fitting
     """
     return deepcopy(DEFAULT_RESULT)
+
 
 def get_default_mcal_result():
     """
@@ -67,6 +69,7 @@ class BootstrapperBase(object):
     """
     bootstrap a fit on the object.
     """
+
     def __init__(self, obs):
         self.mbobs = ngmix.observation.get_mb_obs(obs)
 
@@ -76,15 +79,17 @@ class BootstrapperBase(object):
         """
         raise NotImplementedError("implement in a child class")
 
+
 class MaxBootstrapper(BootstrapperBase):
     """
     bootstrap maximum likelihood fits
     """
+
     def __init__(self, obs, config, prior, rng):
-        super(MaxBootstrapper,self).__init__(obs)
-        self.config=config
-        self.prior=prior
-        self.rng=rng
+        super(MaxBootstrapper, self).__init__(obs)
+        self.config = config
+        self.prior = prior
+        self.rng = rng
 
         self._set_default_result()
 
@@ -104,13 +109,13 @@ class MaxBootstrapper(BootstrapperBase):
         The result dict is modified to set the fit data and set flags.  A gmix
         object set for the psf observations if the fits succeed
         """
-        res=self.result
+        res = self.result
 
         # we have now begun processing, so set to zero
         res['flags'] = 0
 
-        pres=res['psf']
-        pres_byband=pres['byband']
+        pres = res['psf']
+        pres_byband = pres['byband']
 
         pres['flags'] = 0
 
@@ -118,32 +123,32 @@ class MaxBootstrapper(BootstrapperBase):
         sigma_guess = pconf['fwhm_guess']/2.35
         Tguess = 2*sigma_guess**2
 
-        for band,obslist in enumerate(self.mbobs):
-            assert len(obslist)==1,"multi-epoch fitting is not supported"
-            obs=obslist[0]
+        for band, obslist in enumerate(self.mbobs):
+            assert len(obslist) == 1, "multi-epoch fitting is not supported"
+            obs = obslist[0]
 
             psf_obs = obs.psf
             runner = self._get_psf_runner(psf_obs, Tguess)
             runner.go(ntry=pconf['max_pars']['ntry'])
-            fitter=runner.fitter
-            tres=fitter.get_result()
+            fitter = runner.fitter
+            tres = fitter.get_result()
 
             pres['flags'] |= tres['flags']
 
             if tres['flags'] == 0:
                 gmix = fitter.get_gmix()
                 psf_obs.gmix = gmix
-                g1,g2,T=gmix.get_g1g2T()
+                g1, g2, T = gmix.get_g1g2T()
                 tres['g1'] = g1
                 tres['g2'] = g2
                 tres['T'] = T
             else:
-                filt=self.cdict['filters'][band]
+                filt = self.cdict['filters'][band]
                 logger.debug('psf fit failed for filter %s' % filt)
 
             pres_byband.append(tres)
 
-        if pres['flags']==0:
+        if pres['flags'] == 0:
             self._set_mean_psf_stats(pres)
         else:
             res['flags'] |= procflags.PSF_FIT_FAILURE
@@ -161,33 +166,33 @@ class MaxBootstrapper(BootstrapperBase):
 
         mbobs = self.mbobs
 
-        res=self.result
-        pfres=res['psf_flux']
-        pfres['flags']=0
+        res = self.result
+        pfres = res['psf_flux']
+        pfres['flags'] = 0
 
-        res_byband=pfres['byband']
+        res_byband = pfres['byband']
 
-        for band,obs_list in enumerate(mbobs):
+        for band, obs_list in enumerate(mbobs):
 
             if not obs_list[0].has_psf_gmix():
-                filt=self.cdict['filters'][band]
-                tres={'flags':procflags.NO_ATTEMPT}
+                filt = self.cdict['filters'][band]
+                tres = {'flags': procflags.NO_ATTEMPT}
                 logger.debug('not fitting psf flux in '
-                      'filter %s due to missing PSF fit' % filt)
-            else: 
-                fitter=ngmix.fitting.TemplateFluxFitter(
+                             'filter %s due to missing PSF fit' % filt)
+            else:
+                fitter = ngmix.fitting.TemplateFluxFitter(
                     obs_list,
                     do_psf=True,
                     normalize_psf=normalize_psf,
                 )
                 fitter.go()
 
-                tres=fitter.get_result()
+                tres = fitter.get_result()
 
             if tres['flags'] != 0:
                 logger.debug('psf flux fit failed: %s' % tres['flags'])
-                pfres['flags'] |= procflags.PSF_FLUX_FIT_FAILURE 
-                res['flags'] |= procflags.PSF_FLUX_FIT_FAILURE 
+                pfres['flags'] |= procflags.PSF_FLUX_FIT_FAILURE
+                res['flags'] |= procflags.PSF_FLUX_FIT_FAILURE
 
             res_byband.append(tres)
 
@@ -196,22 +201,22 @@ class MaxBootstrapper(BootstrapperBase):
         fit the model to the object
         """
 
-        res=self.result
+        res = self.result
 
         # we need psfs to be fit and psf fluxes to be fit
-        pfres=res['psf_flux']
+        pfres = res['psf_flux']
         if pfres['flags'] != 0:
             raise RuntimeError(
                 'psf flux flags non zero: %d.  '
                 'cannot fit object without psf fluxes' % pfres['flags']
             )
 
-        self.result['obj']['flags']=0
+        self.result['obj']['flags'] = 0
 
-        runner=self._get_runner()
+        runner = self._get_runner()
         runner.go(ntry=self.config['obj']['max_pars']['ntry'])
 
-        tres=runner.fitter.get_result()
+        tres = runner.fitter.get_result()
 
         res['obj'].update(tres)
         if res['obj']['flags'] != 0:
@@ -221,9 +226,10 @@ class MaxBootstrapper(BootstrapperBase):
         """
         set parameters from the modeling
         """
+
     def _set_mean_psf_stats(self, pres):
 
-        byband=pres['byband']
+        byband = pres['byband']
 
         g1 = np.array([t['g1'] for t in byband])
         g2 = np.array([t['g2'] for t in byband])
@@ -237,11 +243,11 @@ class MaxBootstrapper(BootstrapperBase):
         """
         get a runner to be used for fitting the psfs
         """
-        pconf=self.config['psf']
-        model=pconf['model']
+        pconf = self.config['psf']
+        model = pconf['model']
         if 'coellip' in model:
-            ngauss=ngmix.bootstrap.get_coellip_ngauss(model)
-            runner=ngmix.bootstrap.PSFRunnerCoellip(
+            ngauss = ngmix.bootstrap.get_coellip_ngauss(model)
+            runner = ngmix.bootstrap.PSFRunnerCoellip(
                 obs,
                 Tguess,
                 ngauss,
@@ -251,7 +257,7 @@ class MaxBootstrapper(BootstrapperBase):
         elif 'em' in model:
             raise NotImplementedError("implement EM psf fitting")
         else:
-            runner=ngmix.bootstrap.PSFRunner(
+            runner = ngmix.bootstrap.PSFRunner(
                 obs,
                 model,
                 Tguess,
@@ -265,23 +271,23 @@ class MaxBootstrapper(BootstrapperBase):
         get a runner to be used for fitting the object
         """
 
-        objconf=self.config['obj']
+        objconf = self.config['obj']
 
-        max_pars={}
+        max_pars = {}
         max_pars.update(objconf['max_pars'])
-        max_pars['method']='lm'
+        max_pars['method'] = 'lm'
 
-        guesser=self._get_guesser()
+        guesser = self._get_guesser()
 
-        if objconf['model'] in ['bd','bdf']:
-            runner=ngmix.bootstrap.BDFRunner(
+        if objconf['model'] in ['bd', 'bdf']:
+            runner = ngmix.bootstrap.BDFRunner(
                 self.mbobs,
                 max_pars,
                 guesser,
                 prior=self.prior,
             )
         else:
-            runner=ngmix.bootstrap.MaxRunner(
+            runner = ngmix.bootstrap.MaxRunner(
                 self.mbobs,
                 objconf['model'],
                 max_pars,
@@ -295,24 +301,24 @@ class MaxBootstrapper(BootstrapperBase):
         """
         get a guesser for the model parameters
         """
-        pfres=self.result['psf_flux']
+        pfres = self.result['psf_flux']
         if pfres['flags'] != 0:
             raise RuntimeError(
                 'psf flux flags non zero: %d.  '
                 'cannot fit object without psf fluxes' % pfres['flags']
             )
 
-        Tguess=self.result['psf']['T_mean']
+        Tguess = self.result['psf']['T_mean']
         flux_guesses = [t['flux'] for t in pfres['byband']]
 
-        if self.config['obj']['model'] in ['bd','bdf']:
-            guesser=ngmix.guessers.BDFGuesser(
+        if self.config['obj']['model'] in ['bd', 'bdf']:
+            guesser = ngmix.guessers.BDFGuesser(
                 Tguess,
                 flux_guesses,
                 self.prior,
             )
         else:
-            guesser=ngmix.guessers.TFluxAndPriorGuesser(
+            guesser = ngmix.guessers.TFluxAndPriorGuesser(
                 Tguess,
                 flux_guesses,
                 self.prior,
@@ -323,20 +329,22 @@ class MaxBootstrapper(BootstrapperBase):
     def _set_default_result(self):
         self._result = get_default_result()
 
+
 class MetacalMaxBootstrapper(object):
     """
     do metacal with fits using maximum likelihood
     """
+
     def __init__(self,
                  mbobs,
                  config,
                  prior,
                  rng):
 
-        self.mbobs=mbobs
-        self.config=config
-        self.prior=prior
-        self.rng=rng
+        self.mbobs = mbobs
+        self.config = config
+        self.prior = prior
+        self.rng = rng
 
         self._set_default_result()
 
@@ -352,21 +360,20 @@ class MetacalMaxBootstrapper(object):
         do all the processing necessary for metacal
         """
 
-        res=self.result
+        res = self.result
         res['mcal_flags'] = 0
 
-        config=self.config
+        config = self.config
 
-        if config['metacal'].get('symmetrize_psf',False):
+        if config['metacal'].get('symmetrize_psf', False):
             self._do_psf_fits_for_symmetrize(self.mbobs)
             if res['mcal_flags'] != 0:
                 return
 
-        mdict=ngmix.metacal.get_all_metacal(
+        mdict = ngmix.metacal.get_all_metacal(
             self.mbobs,
             **config['metacal'],
         )
-
 
         for type, tmbobs in mdict.items():
             self._do_one_metacal(tmbobs, type)
@@ -377,16 +384,16 @@ class MetacalMaxBootstrapper(object):
 
         the result will be set and possibly flags
         """
-        res=self.result
+        res = self.result
 
-        boot=self._get_one_bootstrapper(mbobs)
+        boot = self._get_one_bootstrapper(mbobs)
         boot.fit_psfs()
         boot.fit_psf_fluxes()
 
-        if boot.result['psf']['flags'] !=0:
+        if boot.result['psf']['flags'] != 0:
             logger.debug('skipping model fit due psf fit failure')
             res['mcal_flags'] |= procflags.METACAL_PSF_FAILURE
-        elif boot.result['psf_flux']['flags']!=0:
+        elif boot.result['psf_flux']['flags'] != 0:
             logger.debug('skipping model fit due psf flux fit failure')
             res['mcal_flags'] |= procflags.METACAL_PSF_FLUX_FAILURE
         else:
@@ -396,14 +403,13 @@ class MetacalMaxBootstrapper(object):
 
         res[type] = boot.result
 
-
     def _do_psf_fits_for_symmetrize(self, mbobs):
         """
         run psf fits *before* the metacal fits
         so we can do symmetrization
         """
 
-        boot=self._get_one_bootstrapper(mbobs)
+        boot = self._get_one_bootstrapper(mbobs)
         boot.fit_psfs()
 
         if boot.result['psf']['flags'] != 0:
@@ -425,6 +431,3 @@ class MetacalMaxBootstrapper(object):
 
     def _set_default_result(self):
         self._result = get_default_mcal_result()
-
-
-

--- a/python/lsst/meas/extensions/ngmix/config.py
+++ b/python/lsst/meas/extensions/ngmix/config.py
@@ -1,6 +1,7 @@
 from lsst.pex.config import Field, ListField, ConfigField, Config, ChoiceField
 from .processCoaddsTogether import ProcessCoaddsTogetherConfig
 
+
 class MetacalConfig(Config):
     """
     configuration of metacalibration
@@ -9,7 +10,7 @@ class MetacalConfig(Config):
     """
     types = ListField(
         dtype=str,
-        default=['noshear','1p','1m','2p','2m'],
+        default=['noshear', '1p', '1m', '2p', '2m'],
         optional=True,
         doc='types of images to create',
     )
@@ -20,6 +21,7 @@ class MetacalConfig(Config):
         doc=('Use round Gaussian for the PSF, based on a '
              'fit to the PSF image'),
     )
+
 
 class StampsConfig(Config):
     """
@@ -47,7 +49,6 @@ class StampsConfig(Config):
         doc='bits to ignore when calculating the background noise',
     )
 
-
     bits_to_null = ListField(
         dtype=str,
         default=[],
@@ -67,7 +68,6 @@ class StampsConfig(Config):
     )
 
 
-
 class LeastsqConfig(Config):
     """
     configuration for the likelihood fitting using scipy.leastsq
@@ -85,6 +85,7 @@ class LeastsqConfig(Config):
         doc='ftol paramter for scipy.leastsq',
     )
 
+
 class MaxConfig(Config):
     ntry = Field(
         dtype=int,
@@ -95,6 +96,7 @@ class MaxConfig(Config):
         doc="parameters for scipy.leastsq",
     )
 
+
 class CenPriorConfig(Config):
     """
     configuration of the prior for the center position
@@ -102,11 +104,12 @@ class CenPriorConfig(Config):
     type = ChoiceField(
         dtype=str,
         allowed={
-            "gauss2d":"2d gaussian",
+            "gauss2d": "2d gaussian",
         },
         doc="type of prior for center",
     )
     pars = ListField(dtype=float, doc="parameters for the center prior")
+
 
 class GPriorConfig(Config):
     """
@@ -115,11 +118,12 @@ class GPriorConfig(Config):
     type = ChoiceField(
         dtype=str,
         allowed={
-            "ba":"See Bernstein & Armstrong",
+            "ba": "See Bernstein & Armstrong",
         },
         doc="type of prior for ellipticity g",
     )
     pars = ListField(dtype=float, doc="parameters for the ellipticity prior")
+
 
 class TPriorConfig(Config):
     """
@@ -128,11 +132,12 @@ class TPriorConfig(Config):
     type = ChoiceField(
         dtype=str,
         allowed={
-            "two-sided-erf":"two-sided error function, smoother than a flat prior",
+            "two-sided-erf": "two-sided error function, smoother than a flat prior",
         },
         doc="type of prior for the square size T",
     )
     pars = ListField(dtype=float, doc="parameters for the T prior")
+
 
 class FluxPriorConfig(Config):
     """
@@ -141,11 +146,12 @@ class FluxPriorConfig(Config):
     type = ChoiceField(
         dtype=str,
         allowed={
-            "two-sided-erf":"two-sided error function, smoother than a flat prior",
+            "two-sided-erf": "two-sided error function, smoother than a flat prior",
         },
         doc="type of prior for the flux; gets repeated for multiple bands",
     )
     pars = ListField(dtype=float, doc="parameters for the flux prior")
+
 
 class FracdevPriorConfig(Config):
     """
@@ -155,7 +161,7 @@ class FracdevPriorConfig(Config):
     type = ChoiceField(
         dtype=str,
         allowed={
-            "gauss":"gaussian prior on fracdev",
+            "gauss": "gaussian prior on fracdev",
         },
         doc="type of prior for fracdev",
     )
@@ -164,6 +170,7 @@ class FracdevPriorConfig(Config):
         optional=True,
         doc="parameters for the fracdev prior",
     )
+
 
 class ObjectPriorsConfig(Config):
     """
@@ -178,9 +185,10 @@ class ObjectPriorsConfig(Config):
     fracdev = ConfigField(
         dtype=FracdevPriorConfig,
         default=None,
-        #optional=True,
+        # optional=True,
         doc="prior on fracdev",
     )
+
 
 class MaxFitConfigBase(Config):
     """
@@ -191,6 +199,7 @@ class MaxFitConfigBase(Config):
         doc="parameters for maximum likelihood fitting with scipy.leastsq",
     )
 
+
 class PSFMaxFitConfig(MaxFitConfigBase):
     """
     PSF fitting configuration using maximum likelihood
@@ -200,9 +209,9 @@ class PSFMaxFitConfig(MaxFitConfigBase):
     model = ChoiceField(
         dtype=str,
         allowed={
-            "gauss":"gaussian model",
-            "coellip2":"coelliptical 2 gauss model",
-            "coellip3":"coelliptical 3 gauss model",
+            "gauss": "gaussian model",
+            "coellip2": "coelliptical 2 gauss model",
+            "coellip3": "coelliptical 3 gauss model",
         },
         doc="The model to fit with ngmix",
     )
@@ -221,12 +230,12 @@ class ObjectMaxFitConfig(MaxFitConfigBase):
     model = ChoiceField(
         dtype=str,
         allowed={
-            "gauss":"gaussian model",
-            "exp":"exponential model",
-            "dev":"dev model",
+            "gauss": "gaussian model",
+            "exp": "exponential model",
+            "dev": "dev model",
             # bd and bdf are the same
-            "bd":"bulge+disk model with fixed size ratio",
-            "bdf":"bulge+disk model with fixed size ratio",
+            "bd": "bulge+disk model with fixed size ratio",
+            "bdf": "bulge+disk model with fixed size ratio",
         },
         doc="The model to fit with ngmix",
     )
@@ -264,7 +273,7 @@ class BasicProcessConfig(ProcessCoaddsTogetherConfig):
         optional=True,
         doc='write some image plots',
     )
-    plot_prefix= Field(
+    plot_prefix = Field(
         dtype=str,
         default=None,
         optional=True,
@@ -272,19 +281,19 @@ class BasicProcessConfig(ProcessCoaddsTogetherConfig):
     )
 
 
-
 class ProcessCoaddsNGMixMaxConfig(BasicProcessConfig):
     """
     fit the object and PSF using maximum likelihood
     """
     psf = ConfigField(dtype=PSFMaxFitConfig, doc='psf fitting config')
-    obj = ConfigField(dtype=ObjectMaxFitConfig,doc="object fitting config")
+    obj = ConfigField(dtype=ObjectMaxFitConfig, doc="object fitting config")
 
     def setDefaults(self):
         """
         prefix for the output file
         """
         self.output.name = "deepCoadd_ngmix"
+
 
 class ProcessDeblendedCoaddsNGMixMaxConfig(ProcessCoaddsNGMixMaxConfig):
     """
@@ -303,14 +312,15 @@ class ProcessCoaddsMetacalMaxConfig(BasicProcessConfig):
     perform metacal using maximum likelihood
     """
     psf = ConfigField(dtype=PSFMaxFitConfig, doc='psf fitting config')
-    obj = ConfigField(dtype=ObjectMaxFitConfig,doc='object fitting config')
-    metacal = ConfigField(dtype=MetacalConfig,doc='metacal config')
+    obj = ConfigField(dtype=ObjectMaxFitConfig, doc='object fitting config')
+    metacal = ConfigField(dtype=MetacalConfig, doc='metacal config')
 
     def setDefaults(self):
         """
         prefix for the output file
         """
         self.output.name = "deepCoadd_mcalmax"
+
 
 class ProcessDeblendedCoaddsMetacalMaxConfig(ProcessCoaddsMetacalMaxConfig):
     """
@@ -322,7 +332,3 @@ class ProcessDeblendedCoaddsMetacalMaxConfig(ProcessCoaddsMetacalMaxConfig):
         prefix for the output file
         """
         self.output.name = "deepCoadd_mcalmax_deblended"
-
-
-
-

--- a/python/lsst/meas/extensions/ngmix/mbobs_extractor.py
+++ b/python/lsst/meas/extensions/ngmix/mbobs_extractor.py
@@ -148,10 +148,10 @@ class MBObsExtractor(object):
         maskobj = imobj_sub.mask
         bmask = maskobj.array
 
-        #cen = rec.getCentroid()
+        # cen = rec.getCentroid()
         orig_cen = imobj_sub.getWcs().skyToPixel(rec.getCoord())
         psf_im = self._extract_psf_image(imobj_sub, orig_cen)
-        #psf_im = imobj_sub.getPsf().computeKernelImage(orig_cen).array
+        # psf_im = imobj_sub.getPsf().computeKernelImage(orig_cen).array
 
         # fake the psf pixel noise
         psf_err = psf_im.max()*0.0001
@@ -277,8 +277,7 @@ class MBObsExtractor(object):
         bits_to_ignore = util.get_ored_bits(maskobj, bitnames_to_ignore)
 
         wuse = np.where(
-            (var_image > 0)
-            &
+            (var_image > 0) &
             ((mask & bits_to_ignore) == 0)
         )
 
@@ -287,7 +286,7 @@ class MBObsExtractor(object):
             weight[:, :] = 1.0/medvar
         else:
             self.log.debug('    weight is all zero, found none that passed cuts')
-            #_print_bits(maskobj, bitnames_to_ignore)
+            # _print_bits(maskobj, bitnames_to_ignore)
 
         bitnames_to_null = self.config['stamps']['bits_to_null']
         if len(bitnames_to_null) > 0:
@@ -303,8 +302,9 @@ class MBObsExtractor(object):
         """
         check for consistency between the images.
 
-        TODO An assertion is currently used, we may want to raise an appropriate
-        exception
+        .. todo::
+           An assertion is currently used, we may want to raise an
+           appropriate exception.
         """
         xy0 = None
         for filt in self.config['filters']:
@@ -346,7 +346,7 @@ def _get_padded_sub_image(original, bbox):
         result.setPsf(original.getPsf())
         result.setWcs(original.getWcs())
         result.setPhotoCalib(original.getPhotoCalib())
-        #result.image.array[:, :] = float("nan")
+        # result.image.array[:, :] = float("nan")
         result.image.array[:, :] = 0.0
         result.variance.array[:, :] = float("inf")
         result.mask.array[:, :] = np.uint16(result.mask.getPlaneBitMask("NO_DATA"))

--- a/python/lsst/meas/extensions/ngmix/mbobs_extractor.py
+++ b/python/lsst/meas/extensions/ngmix/mbobs_extractor.py
@@ -365,7 +365,6 @@ def _get_padded_sub_image(original, bbox):
 
 def _print_bits(maskobj, bitnames):
     mask = maskobj.array
-    bits = 0
     for ibit, bitname in enumerate(bitnames):
         bitval = maskobj.getPlaneBitMask(bitname)
         w = np.where((mask & bitval) != 0)

--- a/python/lsst/meas/extensions/ngmix/priors.py
+++ b/python/lsst/meas/extensions/ngmix/priors.py
@@ -1,12 +1,13 @@
 import ngmix
 from ngmix.joint_prior import PriorSimpleSep, PriorBDFSep
 
+
 def get_joint_prior(objconf, nband, rng):
     """
     get a joint prior on parameters used in the object maximum
     likelihood fitting
     """
-    conf=objconf['priors']
+    conf = objconf['priors']
 
     cen_prior = _get_cen_prior(conf['cen'], rng)
     g_prior = _get_g_prior(conf['g'], rng)
@@ -16,7 +17,7 @@ def get_joint_prior(objconf, nband, rng):
     if nband > 1:
         flux_prior = [flux_prior]*nband
 
-    if objconf['model']=='bd':
+    if objconf['model'] == 'bd':
         fracdev_prior = _get_generic_prior(
             conf['fracdev'],
             rng,
@@ -39,19 +40,21 @@ def get_joint_prior(objconf, nband, rng):
 
     return jprior
 
+
 def _get_cen_prior(conf, rng):
-    if conf['type']=='gauss2d':
-        assert len(conf['pars'])==1,"gauss2d cen prior requires 1 parameters"
-        width=conf['pars'][0]
-        prior=ngmix.priors.CenPrior(0.0, 0.0, width, width, rng=rng)
+    if conf['type'] == 'gauss2d':
+        assert len(conf['pars']) == 1, "gauss2d cen prior requires 1 parameters"
+        width = conf['pars'][0]
+        prior = ngmix.priors.CenPrior(0.0, 0.0, width, width, rng=rng)
     else:
         raise ValueError("bad cen prior: '%s'" % conf['type'])
 
     return prior
 
+
 def _get_g_prior(conf, rng):
-    if conf['type'] =='ba':
-        assert len(conf['pars'])==1,"BA g prior requires 1 parameters"
+    if conf['type'] == 'ba':
+        assert len(conf['pars']) == 1, "BA g prior requires 1 parameters"
         g_prior = ngmix.priors.GPriorBA(*conf['pars'], rng=rng)
     else:
         raise ValueError("bad g prior '%s'" % conf['type'])
@@ -61,12 +64,12 @@ def _get_g_prior(conf, rng):
 
 def _get_generic_prior(conf, rng, bounds=None):
 
-    if conf['type']=='gauss':
-        assert len(conf['pars'])==2,"gauss requires 2 parameters"
+    if conf['type'] == 'gauss':
+        assert len(conf['pars']) == 2, "gauss requires 2 parameters"
         prior = ngmix.priors.Normal(*conf['pars'], bounds=bounds, rng=rng)
 
-    elif conf['type']=='two-sided-erf':
-        assert len(conf['pars'])==4,"two-sided-erf requires 4 parameters"
+    elif conf['type'] == 'two-sided-erf':
+        assert len(conf['pars']) == 4, "two-sided-erf requires 4 parameters"
         prior = ngmix.priors.TwoSidedErf(*conf['pars'])
 
     else:

--- a/python/lsst/meas/extensions/ngmix/priors.py
+++ b/python/lsst/meas/extensions/ngmix/priors.py
@@ -1,5 +1,4 @@
 import ngmix
-from ngmix.joint_prior import PriorSimpleSep, PriorBDFSep
 
 
 def get_joint_prior(objconf, nband, rng):

--- a/python/lsst/meas/extensions/ngmix/processCoaddsNGMix.py
+++ b/python/lsst/meas/extensions/ngmix/processCoaddsNGMix.py
@@ -773,7 +773,6 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
 
             conf = self.cdict
             nband = len(conf['filters'])
-            model = conf['obj']['model']
             self._prior = priors.get_joint_prior(
                 conf['obj'],
                 nband,
@@ -1092,7 +1091,6 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
         """
         get a namer for this output type
         """
-        front = 'mcal'
 
         back = None
         if type is not None:
@@ -1163,7 +1161,6 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
 
             conf = self.cdict
             nband = len(conf['filters'])
-            model = conf['obj']['model']
             self._prior = priors.get_joint_prior(
                 conf['obj'],
                 nband,

--- a/python/lsst/meas/extensions/ngmix/processCoaddsNGMix.py
+++ b/python/lsst/meas/extensions/ngmix/processCoaddsNGMix.py
@@ -201,7 +201,8 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
 
             self._copy_result(mbobs, res, outRecord)
 
-            # Remove the deblended pixels for this object so we can process the next one.
+            # Remove the deblended pixels for this object so we can process
+            # the next one.
             if replacers is not None:
                 for r in replacers.values():
                     r.removeSource(refRecord.getId())
@@ -472,7 +473,8 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
             # mean over filters
             (pn('g2_mean'), 'mean over filters of component 2 of the PSF ellipticity', np.float64, ''),
             (pn('g1_mean'), 'mean over filters of component 2 of the PSF ellipticity', np.float64, ''),
-            (pn('T_mean'), 'mean over filters <x^2> + <y^2> for the gaussian mixture', np.float64, 'arcsec^2'),
+            (pn('T_mean'), 'mean over filters <x^2> + <y^2> for the gaussian mixture', np.float64,
+             'arcsec^2'),
         ]
 
         # PSF measurements by filter
@@ -491,7 +493,8 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
         for filt in config['filters']:
             pfn = self.get_psf_flux_namer(filt)
             mtypes += [
-                (pfn('flux_flags'), 'flags for PSF template flux fitting in the %s filter' % filt, np.float64, ''),
+                (pfn('flux_flags'), 'flags for PSF template flux fitting in the %s filter' % filt,
+                 np.float64, ''),
                 (pfn('flux'), 'PSF template flux in the %s filter' % filt, np.float64, ''),
                 (pfn('flux_err'), 'error on PSF template flux in the %s filter' % filt, np.float64, ''),
             ]
@@ -828,7 +831,8 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
             # mean over filters
             (pn('g2_mean'), 'mean over filters of component 2 of the PSF ellipticity', np.float64, ''),
             (pn('g1_mean'), 'mean over filters of component 2 of the PSF ellipticity', np.float64, ''),
-            (pn('T_mean'), 'mean over filters <x^2> + <y^2> for the gaussian mixture', np.float64, 'arcsec^2'),
+            (pn('T_mean'), 'mean over filters <x^2> + <y^2> for the gaussian mixture', np.float64,
+             'arcsec^2'),
         ]
 
         # PSF measurements by filter
@@ -847,9 +851,14 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
         # for filt in config['filters']:
         #    pfn=self.get_psf_flux_namer(filt)
         #    mtypes += [
-        #        (pfn('flux_flags'),'flags for PSF template flux fitting in the %s filter' % filt,np.float64,''),
-        #        (pfn('flux'),'PSF template flux in the %s filter' % filt,np.float64,''),
-        #        (pfn('flux_err'),'error on PSF template flux in the %s filter' % filt,np.float64,''),
+        #        (pfn('flux_flags'),
+        #         'flags for PSF template flux fitting in the %s filter' %
+        #         filt,np.float64, ''),
+        #        (pfn('flux'),'PSF template flux in the %s filter' % filt,
+        #         np.float64, ''),
+        #        (pfn('flux_err'),
+        #         'error on PSF template flux in the %s filter' % filt,
+        #         np.float64, ''),
         #    ]
 
         # object fitting related fields
@@ -976,7 +985,7 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
             self._copy_psf_fit_result(res['noshear']['psf'], output)
             self._copy_psf_fit_results_byband(res['noshear']['psf'], output)
 
-            #self._copy_psf_flux_results_byband(res['psf_flux'], output)
+            # self._copy_psf_flux_results_byband(res['psf_flux'], output)
 
             self._copy_model_result(res, output)
 
@@ -1182,8 +1191,7 @@ class ProcessDeblendedCoaddsNGMixMaxTask(ProcessCoaddsNGMixMaxTask):
         make sure we are using the deblended images
         """
         check = (
-            replacers is not None
-            and
+            replacers is not None and
             self.cdict['useDeblends'] is True
         )
         assert check,\
@@ -1207,8 +1215,7 @@ class ProcessDeblendedCoaddsMetacalMaxTask(ProcessCoaddsMetacalMaxTask):
         make sure we are using the deblended images
         """
         check = (
-            replacers is not None
-            and
+            replacers is not None and
             self.cdict['useDeblends'] is True
         )
         assert check,\
@@ -1260,7 +1267,7 @@ def make_image_plots(id, images, ncols=1, titles=None, show=False):
         fig.colorbar(implt, cax=cax)
         a.set_title(title)
 
-    #fig.set_size_inches(np.array(fig.get_size_inches()) * n_images)
+    # fig.set_size_inches(np.array(fig.get_size_inches()) * n_images)
     plt.tight_layout()
     if show:
         plt.show()

--- a/python/lsst/meas/extensions/ngmix/processCoaddsNGMix.py
+++ b/python/lsst/meas/extensions/ngmix/processCoaddsNGMix.py
@@ -93,7 +93,6 @@ __all__ = (
 )
 
 
-
 class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
     """
     Base class for ngmix tasks
@@ -106,8 +105,8 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
         """
         get a dict version of the configuration
         """
-        if not hasattr(self,'_cdict'):
-            self._cdict=self.config.toDict()
+        if not hasattr(self, '_cdict'):
+            self._cdict = self.config.toDict()
         return self._cdict
 
     def run(self, images, ref, replacers, imageId):
@@ -116,7 +115,7 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
         This method should not add or modify self.
 
         So far all children are u sing this exact code so leaving
-        it here for now. If we specialize a lot, might make a 
+        it here for now. If we specialize a lot, might make a
         processor its own object
 
         Parameters
@@ -148,7 +147,7 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
 
         self.set_rng(imageId)
 
-        config=self.cdict
+        config = self.cdict
         self.log.info(pprint.pformat(config))
 
         try:
@@ -163,14 +162,14 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
         # Add mostly-empty rows to it, copying IDs from the ref catalog.
         output.extend(ref, mapper=self.mapper)
 
-        index_range=self.get_index_range(output)
+        index_range = self.get_index_range(output)
 
         for n, (outRecord, refRecord) in enumerate(zip(output, ref)):
             if n < index_range[0] or n > index_range[1]:
                 continue
 
             if (n % 100) == 0:
-                self.log.info('index: %06d/%06d' % (n,index_range[1]))
+                self.log.info('index: %06d/%06d' % (n, index_range[1]))
             nproc += 1
 
             outRecord.setFootprint(None)  # copied from ref; don't need to write these again
@@ -182,7 +181,7 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
 
             if extractor is None:
                 # we were missing a band most likely
-                res=self._get_default_result()
+                res = self._get_default_result()
                 mbobs = None
             else:
 
@@ -192,7 +191,7 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
                 except MBObsMissingDataError as err:
                     self.log.debug(str(err))
                     mbobs = None
-                    res=self._get_default_result()
+                    res = self._get_default_result()
                 except ngmix.GMixFatalError as err:
                     # this occurs when we have an all zero weight map
                     self.log.debug(str(err))
@@ -238,21 +237,21 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
         flags = 0
 
         bitnames_to_cut = self.cdict['stamps']['bits_to_cut']
-        for iband,obslist in enumerate(mbobs):
-            obs=obslist[0]
+        for iband, obslist in enumerate(mbobs):
+            obs = obslist[0]
 
             if len(bitnames_to_cut) > 0:
                 maskobj = obs.meta['maskobj']
-                bits_to_cut=util.get_ored_bits(maskobj, bitnames_to_cut)
-                w=np.where( (obs.bmask & bits_to_cut) != 0 )
+                bits_to_cut = util.get_ored_bits(maskobj, bitnames_to_cut)
+                w = np.where((obs.bmask & bits_to_cut) != 0)
                 if w[0].size > 0:
 
-                    band=self.cdict['filters'][iband]
+                    band = self.cdict['filters'][iband]
 
                     self.log.debug(
                         'setting IMAGE_FLAGS '
                         'because in band %s one of these '
-                        'are set %s' % (band,str(bitnames_to_cut))
+                        'are set %s' % (band, str(bitnames_to_cut))
                     )
                     flags |= procflags.IMAGE_FLAGS
 
@@ -270,13 +269,13 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
         if mzfrac >= 1.0:
             return flags
 
-        for iband,frac in enumerate(maskfrac_byband):
+        for iband, frac in enumerate(maskfrac_byband):
             if frac > mzfrac:
-                band=self.cdict['filters'][iband]
+                band = self.cdict['filters'][iband]
                 self.log.debug(
                     'setting HIGH_MASKFRAC in filter %s '
                     'because zero weight frac '
-                    'exceeds max: %g > %g' % (band,frac,mzfrac)
+                    'exceeds max: %g > %g' % (band, frac, mzfrac)
                 )
                 flags |= procflags.HIGH_MASKFRAC
 
@@ -288,18 +287,17 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
         in any of the stamps
         """
 
-        nband=len(mbobs)
+        nband = len(mbobs)
         maskfrac_byband = np.zeros(nband)
 
-        for band,obslist in enumerate(mbobs):
+        for band, obslist in enumerate(mbobs):
             for obs in obslist:
 
-                w=np.where(obs.weight <= 0.0)
+                w = np.where(obs.weight <= 0.0)
                 maskfrac_byband[band] = w[0].size/float(obs.weight.size)
 
         maskfrac = maskfrac_byband.mean()
         return maskfrac, maskfrac_byband
-
 
     def _get_default_result(self):
         """
@@ -312,30 +310,29 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
         Get the range of indices to process.  If these were not set in the
         configuration, [0,cat.size] is returned
         """
-        if not hasattr(self,'_index_range'):
+        if not hasattr(self, '_index_range'):
 
-            ntot=len(cat)
-            start=self.cdict['start_index']
-            num=self.cdict['num_to_process']
+            ntot = len(cat)
+            start = self.cdict['start_index']
+            num = self.cdict['num_to_process']
             if start is None:
-                start=0
+                start = 0
             else:
                 if start < 0 or start > ntot-1:
                     raise ValueError(
                         'requested start index %d out '
-                        'of bounds [%d,%d]' % (start,ntot-1)
+                        'of bounds [%d,%d]' % (start, ntot-1)
                     )
 
             if num is None:
-                num=ntot-start
+                num = ntot-start
             if num < 1:
                 raise ValueError(
                     'requested number to process %d '
                     'less than 1' % num
                 )
 
-
-            self._index_range=[start,start+num-1]
+            self._index_range = [start, start+num-1]
 
         return self._index_range
 
@@ -396,10 +393,10 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
         self._rng = np.random.RandomState(seed)
 
     def _make_plots(self, id, mbobs):
-        filters=self.cdict['filters']
+        filters = self.cdict['filters']
 
-        imlist=[o[0].image for o in mbobs]
-        titles=[f for f in filters]
+        imlist = [o[0].image for o in mbobs]
+        titles = [f for f in filters]
 
         imlist += [o[0].weight for o in mbobs]
         titles += [f+' wt' for f in filters]
@@ -407,7 +404,7 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
         imlist += [o[0].bmask for o in mbobs]
         titles += [f+' bmask' for f in filters]
 
-        plt=make_image_plots(
+        plt = make_image_plots(
             id,
             imlist,
             ncols=len(filters),
@@ -415,12 +412,13 @@ class ProcessCoaddsNGMixBaseTask(ProcessCoaddsTogetherTask):
             show=False,
         )
 
-        fname='images-%d.png' % id
+        fname = 'images-%d.png' % id
         if self.cdict['plot_prefix'] is not None:
             fname = self.cdict['plot_prefix'] + fname
 
         self.log.info('saving figure: %s' % fname)
         plt.savefig(fname)
+
 
 class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
     """
@@ -449,41 +447,41 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
         self.mapper.addMinimalSchema(SourceCatalog.Table.makeMinimalSchema(), True)
         schema = self.mapper.getOutputSchema()
 
-        config=self.cdict
+        config = self.cdict
 
-        model=config['obj']['model']
-        n=self.get_namer()
-        pn=self.get_psf_namer()
-        mn=self.get_model_namer()
+        model = config['obj']['model']
+        n = self.get_namer()
+        pn = self.get_psf_namer()
+        mn = self.get_model_namer()
 
         # generic ngmix fields
-        mtypes=[
-            (n('flags'),'overall flags for the processing',np.int32,''),
-            (n('stamp_size'),'size of postage stamp',np.int32,''),
-            (n('maskfrac'),'mean masked fraction',np.float32,''),
+        mtypes = [
+            (n('flags'), 'overall flags for the processing', np.int32, ''),
+            (n('stamp_size'), 'size of postage stamp', np.int32, ''),
+            (n('maskfrac'), 'mean masked fraction', np.float32, ''),
         ]
         for filt in config['filters']:
             mtypes += [
-                (n('maskfrac_%s' % filt),'masked fraction in %s filter' % filt,np.float32,''),
+                (n('maskfrac_%s' % filt), 'masked fraction in %s filter' % filt, np.float32, ''),
             ]
 
         # psf fitting related fields
         mtypes += [
-            (pn('flags'),'overall flags for the PSF processing',np.int32,''),
+            (pn('flags'), 'overall flags for the PSF processing', np.int32, ''),
 
             # mean over filters
-            (pn('g2_mean'),'mean over filters of component 2 of the PSF ellipticity',np.float64,''),
-            (pn('g1_mean'),'mean over filters of component 2 of the PSF ellipticity',np.float64,''),
-            (pn('T_mean'),'mean over filters <x^2> + <y^2> for the gaussian mixture',np.float64,'arcsec^2'),
+            (pn('g2_mean'), 'mean over filters of component 2 of the PSF ellipticity', np.float64, ''),
+            (pn('g1_mean'), 'mean over filters of component 2 of the PSF ellipticity', np.float64, ''),
+            (pn('T_mean'), 'mean over filters <x^2> + <y^2> for the gaussian mixture', np.float64, 'arcsec^2'),
         ]
 
         # PSF measurements by filter
         for filt in config['filters']:
-            pfn=self.get_psf_namer(filt=filt)
+            pfn = self.get_psf_namer(filt=filt)
             mtypes += [
                 (pfn('flags'), 'overall flags for PSF processing in %s filter' % filt, np.int32, ''),
-                (pfn('row'),'offset from canonical row position',np.float64,'arcsec'),
-                (pfn('col'),'offset from canonical col position',np.float64,'arcsec'),
+                (pfn('row'), 'offset from canonical row position', np.float64, 'arcsec'),
+                (pfn('col'), 'offset from canonical col position', np.float64, 'arcsec'),
                 (pfn('g1'), 'component 1 of the PSF ellipticity in %s filter' % filt, np.float64, ''),
                 (pfn('g2'), 'component 2 of the PSF ellipticity in %s filter' % filt, np.float64, ''),
                 (pfn('T'), '<x^2> + <y^2> for the PSF in %s filter' % filt, np.float64, 'arcsec^2'),
@@ -491,48 +489,47 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
 
         # PSF flux measurements, on the object, by filter
         for filt in config['filters']:
-            pfn=self.get_psf_flux_namer(filt)
+            pfn = self.get_psf_flux_namer(filt)
             mtypes += [
-                (pfn('flux_flags'),'flags for PSF template flux fitting in the %s filter' % filt,np.float64,''),
-                (pfn('flux'),'PSF template flux in the %s filter' % filt,np.float64,''),
-                (pfn('flux_err'),'error on PSF template flux in the %s filter' % filt,np.float64,''),
+                (pfn('flux_flags'), 'flags for PSF template flux fitting in the %s filter' % filt, np.float64, ''),
+                (pfn('flux'), 'PSF template flux in the %s filter' % filt, np.float64, ''),
+                (pfn('flux_err'), 'error on PSF template flux in the %s filter' % filt, np.float64, ''),
             ]
-
 
         # object fitting related fields
         mtypes += [
-            (mn('flags'),'flags for model fit',np.int32,''),
-            (mn('nfev'),'number of function evaluations during fit',np.int32,''),
-            (mn('chi2per'),'chi^2 per degree of freedom',np.float64,''),
-            (mn('dof'),'number of degrees of freedom',np.int32,''),
+            (mn('flags'), 'flags for model fit', np.int32, ''),
+            (mn('nfev'), 'number of function evaluations during fit', np.int32, ''),
+            (mn('chi2per'), 'chi^2 per degree of freedom', np.float64, ''),
+            (mn('dof'), 'number of degrees of freedom', np.int32, ''),
 
-            (mn('s2n'),'S/N for the fit',np.float64,''),
+            (mn('s2n'), 'S/N for the fit', np.float64, ''),
 
-            (mn('row'),'offset from canonical row position',np.float64,'arcsec'),
-            (mn('row_err'),'error on offset from canonical row position',np.float64,'arcsec'),
-            (mn('col'),'offset from canonical col position',np.float64,'arcsec'),
-            (mn('col_err'),'error on offset from canonical col position',np.float64,'arcsec'),
-            (mn('g1'),'component 1 of the ellipticity',np.float64,''),
-            (mn('g1_err'),'error on component 1 of the ellipticity',np.float64,''),
-            (mn('g2'),'component 2 of the ellipticity',np.float64,''),
-            (mn('g2_err'),'error on component 2 of the ellipticity',np.float64,''),
-            (mn('T'),'<x^2> + <y^2> for the gaussian mixture',np.float64,'arcsec^2'),
-            (mn('T_err'),'error on <x^2> + <y^2> for the gaussian mixture',np.float64,'arcsec^2'),
+            (mn('row'), 'offset from canonical row position', np.float64, 'arcsec'),
+            (mn('row_err'), 'error on offset from canonical row position', np.float64, 'arcsec'),
+            (mn('col'), 'offset from canonical col position', np.float64, 'arcsec'),
+            (mn('col_err'), 'error on offset from canonical col position', np.float64, 'arcsec'),
+            (mn('g1'), 'component 1 of the ellipticity', np.float64, ''),
+            (mn('g1_err'), 'error on component 1 of the ellipticity', np.float64, ''),
+            (mn('g2'), 'component 2 of the ellipticity', np.float64, ''),
+            (mn('g2_err'), 'error on component 2 of the ellipticity', np.float64, ''),
+            (mn('T'), '<x^2> + <y^2> for the gaussian mixture', np.float64, 'arcsec^2'),
+            (mn('T_err'), 'error on <x^2> + <y^2> for the gaussian mixture', np.float64, 'arcsec^2'),
         ]
-        if model in ['bd','bdf']:
+        if model in ['bd', 'bdf']:
             mtypes += [
-                (mn('fracdev'),'fraction of light in the bulge',np.float64,''),
-                (mn('fracdev_err'),'error on fraction of light in the bulge',np.float64,''),
+                (mn('fracdev'), 'fraction of light in the bulge', np.float64, ''),
+                (mn('fracdev_err'), 'error on fraction of light in the bulge', np.float64, ''),
             ]
 
         for filt in config['filters']:
-            mfn=self.get_model_flux_namer(filt)
+            mfn = self.get_model_flux_namer(filt)
             mtypes += [
-                (mfn('flux'),'flux in the %s filter' % filt,np.float64,''),
-                (mfn('flux_err'),'error on flux in the %s filter' % filt,np.float64,''),
+                (mfn('flux'), 'flux in the %s filter' % filt, np.float64, ''),
+                (mfn('flux_err'), 'error on flux in the %s filter' % filt, np.float64, ''),
             ]
 
-        for name,doc,dtype,units in mtypes:
+        for name, doc, dtype, units in mtypes:
             schema.addField(
                 name,
                 type=dtype,
@@ -567,22 +564,22 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
 
         flags = self._check_obs(mbobs, maskfrac_byband)
         if flags != 0:
-            res=self._get_default_result()
+            res = self._get_default_result()
             res['maskfrac'], res['maskfrac_byband'] = maskfrac, maskfrac_byband
             res['flags'] = flags
             return res
 
-        boot=self._get_bootstrapper(mbobs)
+        boot = self._get_bootstrapper(mbobs)
         boot.fit_psfs()
         boot.fit_psf_fluxes()
-        if boot.result['psf']['flags'] !=0:
+        if boot.result['psf']['flags'] != 0:
             self.log.warn('    skipping model fit due psf fit failure')
-        elif boot.result['psf_flux']['flags']!=0:
+        elif boot.result['psf_flux']['flags'] != 0:
             self.log.warn('    skipping model fit due psf flux fit failure')
         else:
             boot.fit_model()
 
-        res=boot.result
+        res = boot.result
         res['maskfrac'], res['maskfrac_byband'] = maskfrac, maskfrac_byband
         return res
 
@@ -608,7 +605,7 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
         copy the result dict to the output record
         """
 
-        n=self.get_namer()
+        n = self.get_namer()
 
         if mbobs is None:
             output[n('flags')] = procflags.NO_ATTEMPT
@@ -616,11 +613,11 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
             output[n('flags')] = res['flags']
 
             stamp_shape = mbobs[0][0].image.shape
-            stamp_size=stamp_shape[0]
+            stamp_size = stamp_shape[0]
 
             output[n('stamp_size')] = stamp_size
             output[n('maskfrac')] = res['maskfrac']
-            for ifilt,filt in enumerate(self.cdict['filters']):
+            for ifilt, filt in enumerate(self.cdict['filters']):
                 output[n('maskfrac_%s' % filt)] = res['maskfrac_byband'][ifilt]
 
             self._copy_psf_fit_result(res['psf'], output)
@@ -635,33 +632,33 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
         The statistics here are averaged over all bands
         """
 
-        n=self.get_psf_namer()
+        n = self.get_psf_namer()
         output[n('flags')] = pres['flags']
         if pres['flags'] == 0:
             output[n('g1_mean')] = pres['g1_mean']
             output[n('g2_mean')] = pres['g2_mean']
-            output[n('T_mean')]  = pres['T_mean']
+            output[n('T_mean')] = pres['T_mean']
 
     def _copy_psf_fit_results_byband(self, pres, output):
         """
         copy the PSF result from each band to the output record.
         """
 
-        if len(pres['byband'])==0:
+        if len(pres['byband']) == 0:
             return
 
-        config=self.cdict
-        for ifilt,filt in enumerate(config['filters']):
+        config = self.cdict
+        for ifilt, filt in enumerate(config['filters']):
             filt_res = pres['byband'][ifilt]
 
             if filt_res is not None:
-                n=self.get_psf_namer(filt=filt)
+                n = self.get_psf_namer(filt=filt)
 
                 output[n('flags')] = filt_res['flags']
                 output[n('row')] = filt_res['pars'][0]
                 output[n('col')] = filt_res['pars'][1]
-                if filt_res['flags']==0:
-                    for name in ['g1','g2','T']:
+                if filt_res['flags'] == 0:
+                    for name in ['g1', 'g2', 'T']:
                         output[n(name)] = filt_res[name]
 
     def _copy_psf_flux_results_byband(self, pres, output):
@@ -669,30 +666,29 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
         copy the PSF flux fitting results from each band to the output record.
         """
 
-        if len(pres['byband'])==0:
+        if len(pres['byband']) == 0:
             return
 
-        config=self.cdict
-        for ifilt,filt in enumerate(config['filters']):
+        config = self.cdict
+        for ifilt, filt in enumerate(config['filters']):
             filt_res = pres['byband'][ifilt]
 
             if filt_res is not None:
-                n=self.get_psf_flux_namer(filt=filt)
+                n = self.get_psf_flux_namer(filt=filt)
 
                 output[n('flux_flags')] = filt_res['flags']
-                if filt_res['flags']==0:
+                if filt_res['flags'] == 0:
                     output[n('flux')] = filt_res['flux']
                     output[n('flux_err')] = filt_res['flux_err']
-
 
     def _copy_model_result(self, ores, output):
         """
         copy the model fitting result dict to the output record.
         """
 
-        config=self.cdict
+        config = self.cdict
 
-        mn=self.get_model_namer()
+        mn = self.get_model_namer()
         output[mn('flags')] = ores['flags']
 
         if 'nfev' in ores:
@@ -700,27 +696,27 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
             # if it wasn't attempted
             output[mn('nfev')] = ores['nfev']
 
-        if ores['flags']==0:
-            for n in ['chi2per','dof','s2n']:
+        if ores['flags'] == 0:
+            for n in ['chi2per', 'dof', 's2n']:
                 output[mn(n)] = ores[n]
 
-            ni=[('row',0),('col',1),('g1',2),('g2',3),('T',4)]
-            if self.cdict['obj']['model'] in ['bd','bdf']:
-                ni += [('fracdev',5)]
-                flux_start=6
+            ni = [('row', 0), ('col', 1), ('g1', 2), ('g2', 3), ('T', 4)]
+            if self.cdict['obj']['model'] in ['bd', 'bdf']:
+                ni += [('fracdev', 5)]
+                flux_start = 6
             else:
-                flux_start=5
+                flux_start = 5
 
-            pars=ores['pars']
-            perr=ores['pars_err']
-            for n,i in ni:
+            pars = ores['pars']
+            perr = ores['pars_err']
+            for n, i in ni:
                 output[mn(n)] = pars[i]
                 output[mn(n+'_err')] = perr[i]
 
             for ifilt, filt in enumerate(config['filters']):
 
-                ind=flux_start+ifilt
-                mfn=self.get_model_flux_namer(filt)
+                ind = flux_start+ifilt
+                mfn = self.get_model_flux_namer(filt)
                 output[mfn('flux')] = pars[ind]
                 output[mfn('flux_err')] = perr[ind]
 
@@ -734,37 +730,34 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
         """
         get a namer for this output type
         """
-        config=self.cdict
-        model=config['obj']['model']
+        config = self.cdict
+        model = config['obj']['model']
         return Namer(front='ngmix_%s' % model)
-
 
     def get_psf_namer(self, filt=None):
         """
         get a namer for this output type
         """
-        front='ngmix_psf'
+        front = 'ngmix_psf'
         if filt is not None:
-            front='%s_%s' % (front,filt)
+            front = '%s_%s' % (front, filt)
         return Namer(front=front)
-
 
     def get_model_flux_namer(self, filt):
         """
         get a namer for this output type
         """
-        config=self.cdict
-        model=config['obj']['model']
-        front='ngmix_%s' % model
+        config = self.cdict
+        model = config['obj']['model']
+        front = 'ngmix_%s' % model
         return Namer(front=front, back=filt)
 
     def get_psf_flux_namer(self, filt):
         """
         get a namer for this output type
         """
-        front='ngmix_psf'
+        front = 'ngmix_psf'
         return Namer(front=front, back=filt)
-
 
     @property
     def prior(self):
@@ -775,9 +768,9 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
             # this is temporary until I can figure out how to get
             # an existing seeded rng
 
-            conf=self.cdict
-            nband=len(conf['filters'])
-            model=conf['obj']['model']
+            conf = self.cdict
+            nband = len(conf['filters'])
+            model = conf['obj']['model']
             self._prior = priors.get_joint_prior(
                 conf['obj'],
                 nband,
@@ -785,7 +778,6 @@ class ProcessCoaddsNGMixMaxTask(ProcessCoaddsNGMixBaseTask):
             )
 
         return self._prior
-
 
 
 class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
@@ -812,48 +804,47 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
         self.mapper.addMinimalSchema(SourceCatalog.Table.makeMinimalSchema(), True)
         schema = self.mapper.getOutputSchema()
 
-        config=self.cdict
+        config = self.cdict
 
-        model=config['obj']['model']
-        n=self.get_namer()
-        pn=self.get_psf_namer()
+        model = config['obj']['model']
+        n = self.get_namer()
+        pn = self.get_psf_namer()
 
         # generic ngmix fields
-        mtypes=[
-            (n('flags'),'overall flags for the processing',np.int32,''),
-            (n('stamp_size'),'size of postage stamp',np.int32,''),
-            (n('maskfrac'),'mean masked fraction',np.float32,''),
+        mtypes = [
+            (n('flags'), 'overall flags for the processing', np.int32, ''),
+            (n('stamp_size'), 'size of postage stamp', np.int32, ''),
+            (n('maskfrac'), 'mean masked fraction', np.float32, ''),
         ]
         for filt in config['filters']:
             mtypes += [
-                (n('maskfrac_%s' % filt),'masked fraction in %s filter' % filt,np.float32,''),
+                (n('maskfrac_%s' % filt), 'masked fraction in %s filter' % filt, np.float32, ''),
             ]
-
 
         # psf fitting related fields
         mtypes += [
-            (pn('flags'),'overall flags for the PSF processing',np.int32,''),
+            (pn('flags'), 'overall flags for the PSF processing', np.int32, ''),
 
             # mean over filters
-            (pn('g2_mean'),'mean over filters of component 2 of the PSF ellipticity',np.float64,''),
-            (pn('g1_mean'),'mean over filters of component 2 of the PSF ellipticity',np.float64,''),
-            (pn('T_mean'),'mean over filters <x^2> + <y^2> for the gaussian mixture',np.float64,'arcsec^2'),
+            (pn('g2_mean'), 'mean over filters of component 2 of the PSF ellipticity', np.float64, ''),
+            (pn('g1_mean'), 'mean over filters of component 2 of the PSF ellipticity', np.float64, ''),
+            (pn('T_mean'), 'mean over filters <x^2> + <y^2> for the gaussian mixture', np.float64, 'arcsec^2'),
         ]
 
         # PSF measurements by filter
         for filt in config['filters']:
-            pfn=self.get_psf_namer(filt=filt)
+            pfn = self.get_psf_namer(filt=filt)
             mtypes += [
                 (pfn('flags'), 'overall flags for PSF processing in %s filter' % filt, np.int32, ''),
-                (pfn('row'),'offset from canonical row position',np.float64,'arcsec'),
-                (pfn('col'),'offset from canonical col position',np.float64,'arcsec'),
+                (pfn('row'), 'offset from canonical row position', np.float64, 'arcsec'),
+                (pfn('col'), 'offset from canonical col position', np.float64, 'arcsec'),
                 (pfn('g1'), 'component 1 of the PSF ellipticity in %s filter' % filt, np.float64, ''),
                 (pfn('g2'), 'component 2 of the PSF ellipticity in %s filter' % filt, np.float64, ''),
                 (pfn('T'), '<x^2> + <y^2> for the PSF in %s filter' % filt, np.float64, 'arcsec^2'),
             ]
 
         # PSF flux measurements, on the object, by filter
-        #for filt in config['filters']:
+        # for filt in config['filters']:
         #    pfn=self.get_psf_flux_namer(filt)
         #    mtypes += [
         #        (pfn('flux_flags'),'flags for PSF template flux fitting in the %s filter' % filt,np.float64,''),
@@ -863,40 +854,40 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
 
         # object fitting related fields
         for type in config['metacal']['types']:
-            mn=self.get_model_namer(type=type)
+            mn = self.get_model_namer(type=type)
             mtypes += [
-                (mn('flags'),'flags for model fit',np.int32,''),
-                (mn('nfev'),'number of function evaluations during fit',np.int32,''),
-                (mn('chi2per'),'chi^2 per degree of freedom',np.float64,''),
-                (mn('dof'),'number of degrees of freedom',np.int32,''),
+                (mn('flags'), 'flags for model fit', np.int32, ''),
+                (mn('nfev'), 'number of function evaluations during fit', np.int32, ''),
+                (mn('chi2per'), 'chi^2 per degree of freedom', np.float64, ''),
+                (mn('dof'), 'number of degrees of freedom', np.int32, ''),
 
-                (mn('s2n'),'S/N for the fit',np.float64,''),
+                (mn('s2n'), 'S/N for the fit', np.float64, ''),
 
-                (mn('row'),'offset from canonical row position',np.float64,'arcsec'),
-                (mn('row_err'),'error on offset from canonical row position',np.float64,'arcsec'),
-                (mn('col'),'offset from canonical col position',np.float64,'arcsec'),
-                (mn('col_err'),'error on offset from canonical col position',np.float64,'arcsec'),
-                (mn('g1'),'component 1 of the ellipticity',np.float64,''),
-                (mn('g1_err'),'error on component 1 of the ellipticity',np.float64,''),
-                (mn('g2'),'component 2 of the ellipticity',np.float64,''),
-                (mn('g2_err'),'error on component 2 of the ellipticity',np.float64,''),
-                (mn('T'),'<x^2> + <y^2> for the gaussian mixture',np.float64,'arcsec^2'),
-                (mn('T_err'),'error on <x^2> + <y^2> for the gaussian mixture',np.float64,'arcsec^2'),
+                (mn('row'), 'offset from canonical row position', np.float64, 'arcsec'),
+                (mn('row_err'), 'error on offset from canonical row position', np.float64, 'arcsec'),
+                (mn('col'), 'offset from canonical col position', np.float64, 'arcsec'),
+                (mn('col_err'), 'error on offset from canonical col position', np.float64, 'arcsec'),
+                (mn('g1'), 'component 1 of the ellipticity', np.float64, ''),
+                (mn('g1_err'), 'error on component 1 of the ellipticity', np.float64, ''),
+                (mn('g2'), 'component 2 of the ellipticity', np.float64, ''),
+                (mn('g2_err'), 'error on component 2 of the ellipticity', np.float64, ''),
+                (mn('T'), '<x^2> + <y^2> for the gaussian mixture', np.float64, 'arcsec^2'),
+                (mn('T_err'), 'error on <x^2> + <y^2> for the gaussian mixture', np.float64, 'arcsec^2'),
             ]
-            if model in ['bd','bdf']:
+            if model in ['bd', 'bdf']:
                 mtypes += [
-                    (mn('fracdev'),'fraction of light in the bulge',np.float64,''),
-                    (mn('fracdev_err'),'error on fraction of light in the bulge',np.float64,''),
+                    (mn('fracdev'), 'fraction of light in the bulge', np.float64, ''),
+                    (mn('fracdev_err'), 'error on fraction of light in the bulge', np.float64, ''),
                 ]
 
             for filt in config['filters']:
-                mfn=self.get_model_flux_namer(filt, type=type)
+                mfn = self.get_model_flux_namer(filt, type=type)
                 mtypes += [
-                    (mfn('flux'),'flux in the %s filter' % filt,np.float64,''),
-                    (mfn('flux_err'),'error on flux in the %s filter' % filt,np.float64,''),
+                    (mfn('flux'), 'flux in the %s filter' % filt, np.float64, ''),
+                    (mfn('flux_err'), 'error on flux in the %s filter' % filt, np.float64, ''),
                 ]
 
-        for name,doc,dtype,units in mtypes:
+        for name, doc, dtype, units in mtypes:
             schema.addField(
                 name,
                 type=dtype,
@@ -934,14 +925,14 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
 
         flags = self._check_obs(mbobs, maskfrac_byband)
         if flags != 0:
-            res=self._get_default_result()
+            res = self._get_default_result()
             res['maskfrac'], res['maskfrac_byband'] = maskfrac, maskfrac_byband
             res['mcal_flags'] = flags
             return res
 
-        boot=self._get_bootstrapper(mbobs)
+        boot = self._get_bootstrapper(mbobs)
         boot.go()
-        res=boot.result
+        res = boot.result
         res['maskfrac'], res['maskfrac_byband'] = maskfrac, maskfrac_byband
         return res
 
@@ -967,7 +958,7 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
         copy the result dict to the output record
         """
 
-        n=self.get_namer()
+        n = self.get_namer()
 
         if mbobs is None:
             output[n('flags')] = procflags.NO_ATTEMPT
@@ -975,11 +966,11 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
             output[n('flags')] = res['mcal_flags']
 
             stamp_shape = mbobs[0][0].image.shape
-            stamp_size=stamp_shape[0]
+            stamp_size = stamp_shape[0]
 
             output[n('stamp_size')] = stamp_size
             output[n('maskfrac')] = res['maskfrac']
-            for ifilt,filt in enumerate(self.cdict['filters']):
+            for ifilt, filt in enumerate(self.cdict['filters']):
                 output[n('maskfrac_%s' % filt)] = res['maskfrac_byband'][ifilt]
 
             self._copy_psf_fit_result(res['noshear']['psf'], output)
@@ -995,69 +986,68 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
         The statistics here are averaged over all bands
         """
 
-        n=self.get_psf_namer()
+        n = self.get_psf_namer()
         output[n('flags')] = pres['flags']
         if pres['flags'] == 0:
             output[n('g1_mean')] = pres['g1_mean']
             output[n('g2_mean')] = pres['g2_mean']
-            output[n('T_mean')]  = pres['T_mean']
+            output[n('T_mean')] = pres['T_mean']
 
     def _copy_psf_fit_results_byband(self, pres, output):
         """
         copy the PSF result from each band to the output record.
         """
 
-        if len(pres['byband'])==0:
+        if len(pres['byband']) == 0:
             return
 
-        config=self.cdict
-        for ifilt,filt in enumerate(config['filters']):
+        config = self.cdict
+        for ifilt, filt in enumerate(config['filters']):
             filt_res = pres['byband'][ifilt]
 
             if filt_res is not None:
-                n=self.get_psf_namer(filt=filt)
+                n = self.get_psf_namer(filt=filt)
 
                 output[n('flags')] = filt_res['flags']
                 if filt_res['flags'] == 0:
                     output[n('row')] = filt_res['pars'][0]
                     output[n('col')] = filt_res['pars'][1]
-                    if filt_res['flags']==0:
-                        for name in ['g1','g2','T']:
+                    if filt_res['flags'] == 0:
+                        for name in ['g1', 'g2', 'T']:
                             output[n(name)] = filt_res[name]
 
     def _copy_psf_flux_results_byband(self, pres, output):
         """
         copy the PSF flux fitting results from each band to the output record.
         """
-        if len(pres['byband'])==0:
+        if len(pres['byband']) == 0:
             return
 
-        config=self.cdict
-        for ifilt,filt in enumerate(config['filters']):
+        config = self.cdict
+        for ifilt, filt in enumerate(config['filters']):
             filt_res = pres['byband'][ifilt]
 
             if filt_res is not None:
-                n=self.get_psf_flux_namer(filt=filt)
+                n = self.get_psf_flux_namer(filt=filt)
 
                 output[n('flux_flags')] = filt_res['flags']
-                if filt_res['flags']==0:
+                if filt_res['flags'] == 0:
                     output[n('flux')] = filt_res['flux']
                     output[n('flux_err')] = filt_res['flux_err']
-
 
     def _copy_model_result(self, res, output):
         """
         copy the model fitting result dict to the output record.
         """
 
-        config=self.cdict
+        config = self.cdict
 
-        types=config['metacal']['types']
+        types = config['metacal']['types']
 
         for type in types:
-            ores=res[type]['obj']
+            ores = res[type]['obj']
 
-            mn=self.get_model_namer(type=type)
+            mn = self.get_model_namer(type=type)
             output[mn('flags')] = ores['flags']
 
             if 'nfev' in ores:
@@ -1065,27 +1055,27 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
                 # if it wasn't attempted
                 output[mn('nfev')] = ores['nfev']
 
-            if ores['flags']==0:
-                for n in ['chi2per','dof','s2n']:
+            if ores['flags'] == 0:
+                for n in ['chi2per', 'dof', 's2n']:
                     output[mn(n)] = ores[n]
 
-                ni=[('row',0),('col',1),('g1',2),('g2',3),('T',4)]
-                if self.cdict['obj']['model'] in ['bd','bdf']:
-                    ni += [('fracdev',5)]
-                    flux_start=6
+                ni = [('row', 0), ('col', 1), ('g1', 2), ('g2', 3), ('T', 4)]
+                if self.cdict['obj']['model'] in ['bd', 'bdf']:
+                    ni += [('fracdev', 5)]
+                    flux_start = 6
                 else:
-                    flux_start=5
+                    flux_start = 5
 
-                pars=ores['pars']
-                perr=ores['pars_err']
-                for n,i in ni:
+                pars = ores['pars']
+                perr = ores['pars_err']
+                for n, i in ni:
                     output[mn(n)] = pars[i]
                     output[mn(n+'_err')] = perr[i]
 
                 for ifilt, filt in enumerate(config['filters']):
 
-                    ind=flux_start+ifilt
-                    mfn=self.get_model_flux_namer(filt, type=type)
+                    ind = flux_start+ifilt
+                    mfn = self.get_model_flux_namer(filt, type=type)
                     output[mfn('flux')] = pars[ind]
                     output[mfn('flux_err')] = perr[ind]
 
@@ -1093,14 +1083,14 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
         """
         get a namer for this output type
         """
-        front='mcal'
+        front = 'mcal'
 
-        back=None
+        back = None
         if type is not None:
-            if type=='noshear':
-                back=None
+            if type == 'noshear':
+                back = None
             else:
-                back=type
+                back = type
 
         return Namer(front='mcal', back=back)
 
@@ -1108,25 +1098,25 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
         """
         get a namer for this output type
         """
-        front='mcal_psf'
+        front = 'mcal_psf'
         if filt is not None:
-            front='%s_%s' % (front,filt)
+            front = '%s_%s' % (front, filt)
         return Namer(front=front)
 
     def get_model_namer(self, type=None):
         """
         get a namer for this output type
         """
-        config=self.cdict
-        model=config['obj']['model']
+        config = self.cdict
+        model = config['obj']['model']
 
-        front='mcal_%s' % model
+        front = 'mcal_%s' % model
 
         if type is not None:
-            if type=='noshear':
-                back=None
+            if type == 'noshear':
+                back = None
             else:
-                back=type
+                back = type
 
         return Namer(front=front, back=back)
 
@@ -1134,14 +1124,14 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
         """
         get a namer for this output type
         """
-        config=self.cdict
-        model=config['obj']['model']
-        front='mcal_%s' % model
-        back=filt
+        config = self.cdict
+        model = config['obj']['model']
+        front = 'mcal_%s' % model
+        back = filt
 
         if type is not None:
-            if type!='noshear':
-                back='%s_%s' % (back, type)
+            if type != 'noshear':
+                back = '%s_%s' % (back, type)
 
         return Namer(front=front, back=back)
 
@@ -1150,9 +1140,8 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
         get a namer for this output type
         """
         raise NotImplementedError('make work for metacal')
-        front='mcal_psf'
+        front = 'mcal_psf'
         return Namer(front=front, back=filt)
-
 
     @property
     def prior(self):
@@ -1163,9 +1152,9 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
             # this is temporary until I can figure out how to get
             # an existing seeded rng
 
-            conf=self.cdict
-            nband=len(conf['filters'])
-            model=conf['obj']['model']
+            conf = self.cdict
+            nband = len(conf['filters'])
+            model = conf['obj']['model']
             self._prior = priors.get_joint_prior(
                 conf['obj'],
                 nband,
@@ -1178,6 +1167,7 @@ class ProcessCoaddsMetacalMaxTask(ProcessCoaddsNGMixBaseTask):
 # versions for deblended coadds
 # we need an entirely new class to write a different output file
 #
+
 
 class ProcessDeblendedCoaddsNGMixMaxTask(ProcessCoaddsNGMixMaxTask):
     """
@@ -1199,10 +1189,9 @@ class ProcessDeblendedCoaddsNGMixMaxTask(ProcessCoaddsNGMixMaxTask):
         assert check,\
             'You must set useDeblends=True and send noise replacers'
 
-        return super(ProcessDeblendedCoaddsNGMixMaxTask,self).run(
+        return super(ProcessDeblendedCoaddsNGMixMaxTask, self).run(
             images, ref, replacers, imageId,
         )
-
 
 
 class ProcessDeblendedCoaddsMetacalMaxTask(ProcessCoaddsMetacalMaxTask):
@@ -1225,20 +1214,21 @@ class ProcessDeblendedCoaddsMetacalMaxTask(ProcessCoaddsMetacalMaxTask):
         assert check,\
             'You must set useDeblends=True and send noise replacers'
 
-        return super(ProcessDeblendedCoaddsMetacalMaxTask,self).run(
+        return super(ProcessDeblendedCoaddsMetacalMaxTask, self).run(
             images, ref, replacers, imageId,
         )
 
-def make_image_plots(id, images, ncols = 1, titles = None, show=False):
+
+def make_image_plots(id, images, ncols=1, titles=None, show=False):
     """Display a list of images in a single figure with matplotlib.
-    
+
     Parameters
     ---------
     images: List of np.arrays compatible with plt.imshow.
-    
-    ncols (Default = 1): Number of columns in figure (number of rows is 
+
+    ncols (Default = 1): Number of columns in figure (number of rows is
                         set to np.ceil(n_images/float(ncols))).
-    
+
     titles: List of titles corresponding to each image. Must have
             the same length as titles.
     """
@@ -1251,11 +1241,11 @@ def make_image_plots(id, images, ncols = 1, titles = None, show=False):
     nrows = np.ceil(n_images/float(ncols))
 
     if titles is None:
-        titles = ['Image (%d)' % i for i in range(1,n_images + 1)]
+        titles = ['Image (%d)' % i for i in range(1, n_images + 1)]
 
-    dpi=96
-    width=20
-    fig = plt.figure(figsize=(width,width*nrows/ncols), dpi=dpi)
+    dpi = 96
+    width = 20
+    fig = plt.figure(figsize=(width, width*nrows/ncols), dpi=dpi)
 
     fig.suptitle(
         'id: %d' % id
@@ -1264,7 +1254,7 @@ def make_image_plots(id, images, ncols = 1, titles = None, show=False):
         a = fig.add_subplot(nrows, ncols, n + 1)
         if image.ndim == 2:
             plt.gray()
-        implt=plt.imshow(image, interpolation='nearest')
+        implt = plt.imshow(image, interpolation='nearest')
         divider = make_axes_locatable(a)
         cax = divider.append_axes("right", size="5%", pad=0.05)
         fig.colorbar(implt, cax=cax)
@@ -1275,5 +1265,3 @@ def make_image_plots(id, images, ncols = 1, titles = None, show=False):
     if show:
         plt.show()
     return plt
-
-

--- a/python/lsst/meas/extensions/ngmix/processCoaddsTogether.py
+++ b/python/lsst/meas/extensions/ngmix/processCoaddsTogether.py
@@ -87,7 +87,8 @@ class ProcessCoaddsTogetherTask(CmdLineTask, PipelineTask):
     _DefaultName = "processCoaddsTogether"
     ConfigClass = ProcessCoaddsTogetherConfig
 
-    # This feeds the runDataRef() method all bands at once, rather than each one separately.
+    # This feeds the runDataRef() method all bands at once, rather than each
+    # one separately.
     # The name reflects how it's used elsewhere, not what it does
     RunnerClass = MergeSourcesRunner
 

--- a/python/lsst/meas/extensions/ngmix/procflags.py
+++ b/python/lsst/meas/extensions/ngmix/procflags.py
@@ -1,20 +1,20 @@
 # no attempt was made for some measurment.
-NO_ATTEMPT           = 2**0
+NO_ATTEMPT = 2**0
 
 # the weight map had too many zeros in it
-HIGH_MASKFRAC        = 2**1
+HIGH_MASKFRAC = 2**1
 
 # some bits were set in the image that are not allowed
-IMAGE_FLAGS          = 2**2
+IMAGE_FLAGS = 2**2
 
 # PSF fitting failed
-PSF_FIT_FAILURE      = 2**3
+PSF_FIT_FAILURE = 2**3
 
 # the PSF flux fitting failed
 PSF_FLUX_FIT_FAILURE = 2**4
 
 # the object fitting failed
-OBJ_FIT_FAILURE      = 2**5
+OBJ_FIT_FAILURE = 2**5
 
 
 # failure of PSF fitting at some point in metacal

--- a/python/lsst/meas/extensions/ngmix/util.py
+++ b/python/lsst/meas/extensions/ngmix/util.py
@@ -1,50 +1,51 @@
 import numpy as np
 import lsst.log
 
-logger=lsst.log.Log.getLogger("meas.extensions.ngmix.util")
+logger = lsst.log.Log.getLogger("meas.extensions.ngmix.util")
+
 
 class Namer(object):
     """
     create strings with a specified front prefix
     """
-    def __init__(self, front=None, back=None):
-        if front=='':
-            front=None
-        if back=='':
-            back=None
 
-        self.front=front
-        self.back=back
+    def __init__(self, front=None, back=None):
+        if front == '':
+            front = None
+        if back == '':
+            back = None
+
+        self.front = front
+        self.back = back
 
         if self.front is None and self.back is None:
-            self.nomod=True
+            self.nomod = True
         else:
-            self.nomod=False
-
-
+            self.nomod = False
 
     def __call__(self, name):
         if self.nomod:
             return name
         else:
-            n=name
+            n = name
             if self.front is not None:
                 n = '%s_%s' % (self.front, n)
             if self.back is not None:
                 n = '%s_%s' % (n, self.back)
             return n
 
+
 def trim_odd_image(im):
     """
     trim an odd dimension image to by square and with equal distance from
-    canonical center to all edges 
+    canonical center to all edges
     """
 
-    dims=im.shape
+    dims = im.shape
     if dims[0] != dims[1]:
         logger.debug('original dims: %s' % str(dims))
-        assert dims[0] % 2 != 0,'image must have odd dims'
-        assert dims[1] % 2 != 0,'image must have odd dims'
+        assert dims[0] % 2 != 0, 'image must have odd dims'
+        assert dims[1] % 2 != 0, 'image must have odd dims'
 
         dims = np.array(dims)
         cen = (dims-1)//2
@@ -60,9 +61,9 @@ def trim_odd_image(im):
         min_dist = min(distances)
 
         start_row = cen[0] - min_dist
-        end_row   = cen[0] + min_dist
+        end_row = cen[0] + min_dist
         start_col = cen[1] - min_dist
-        end_col   = cen[1] + min_dist
+        end_col = cen[1] + min_dist
 
         # adding +1 for slices
         new_im = im[
@@ -77,12 +78,11 @@ def trim_odd_image(im):
 
     return new_im
 
+
 def get_ored_bits(maskobj, bitnames):
-    bits=0
-    for ibit,bitname in enumerate(bitnames):
+    bits = 0
+    for ibit, bitname in enumerate(bitnames):
         bitval = maskobj.getPlaneBitMask(bitname)
         bits |= bitval
 
     return bits
-
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[flake8]
+max-line-length = 110
+max-doc-length = 79
+ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W504
+exclude = __init__.py
+    example_config/*
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N815 N816 W504

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -53,7 +53,8 @@ class ConverterTestCase(ShapeletTestCase):
         image2.array[:, :] = gmix1.make_image(image2.array.shape)
         self.assertImagesAlmostEqual(image1, image2)
 
-        # Should reject ShapeletFunctions with order > 0, unless ignoreHighOrder==True
+        # Should reject ShapeletFunctions with order > 0,
+        # unless ignoreHighOrder==True
         with self.assertRaises(ValueError):
             problematic = MultiShapeletFunction([self.makeRandomShapeletFunction(order=2) for n in range(4)])
             convertMultiShapeletToGMix(problematic)

--- a/tests/test_emPsfApprox.py
+++ b/tests/test_emPsfApprox.py
@@ -49,7 +49,8 @@ def makeGaussianArray(size, sigma, xc=None, yc=None):
 
 
 def runMeasure(task, schema, exposure):
-    """Run a measurement task which has previously been initialized on a single source
+    """Run a measurement task which has previously been initialized on a
+    single source.
     """
     cat = afwTable.SourceCatalog(schema)
     source = cat.addNew()
@@ -71,7 +72,8 @@ def runMeasure(task, schema, exposure):
 
 
 def makePsf(size, sigma1, mult1, sigma2, mult2):
-    """make a Gaussian with one or two components.  Always square of dimensions size x size
+    """make a Gaussian with one or two components.  Always square of
+    dimensions size x size.
     """
     array0 = makeGaussianArray(size, sigma1)
     array0 *= mult1
@@ -81,7 +83,7 @@ def makePsf(size, sigma1, mult1, sigma2, mult2):
     return measAlg.KernelPsf(kernel)
 
 
-class testEMTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
+class TestEMTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
     """A test case for shape measurement"""
 
     def setUp(self):
@@ -115,8 +117,8 @@ class testEMTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         self.assertEqual(source.get(self.algName + "_flag_rangeError"), False)
         self.assertEqual(source.get(self.algName + "_flag_maxIter"), False)
 
-    #   Test to be sure that we can catch the maximum iterations error
     def testMaxIter(self):
+        """Test to be sure that we can catch the maximum iterations error."""
         msConfig = self.makeConfig()
         msConfig.plugins[self.algName].nGauss = 2
         msConfig.plugins[self.algName].tolerance = 1e-10
@@ -132,8 +134,8 @@ class testEMTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         self.assertEqual(source.get(self.algName + "_flag_rangeError"), False)
         self.assertEqual(source.get(self.algName + "_flag_maxIter"), True)
 
-    #   Test to be sure that we can catch the missing psf error
     def testMissingPsf(self):
+        """Test to be sure that we can catch the missing psf error."""
         msConfig = self.makeConfig()
         schema = afwTable.SourceTable.makeMinimalSchema()
         task = measBase.SingleFrameMeasurementTask(schema=schema, config=msConfig)
@@ -146,8 +148,10 @@ class testEMTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
             self.assertEqual(source.get(self.algName + "_flag_rangeError"), False)
             self.assertEqual(source.get(self.algName + "_flag_maxIter"), False)
 
-    #   Test that the EmPsfApprox plugin produces a more or less reasonable result
     def testEMPlugin(self):
+        """Test that the EmPsfApprox plugin produces a more or less reasonable
+        result."""
+
         msConfig = self.makeConfig()
         msConfig.plugins[self.algName].nGauss = 2
         schema = afwTable.SourceTable.makeMinimalSchema()
@@ -168,8 +172,8 @@ class testEMTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         self.msfKey = lsst.shapelet.MultiShapeletFunctionKey(schema[self.algName],
                                                              lsst.shapelet.HERMITE)
 
-        #   check the two component result to be sure it is close to the input PSF
-        #   we don't control the order of EmPsfApprox, so order by size.
+        # check the two component result to be sure it is close to the input
+        # PSF we don't control the order of EmPsfApprox, so order by size.
         msf = source.get(self.msfKey)
         components = msf.getComponents()
         self.assertEqual(len(components), 2)
@@ -181,9 +185,10 @@ class testEMTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
             temp = comp1
             comp1 = comp0
             comp0 = temp
-        #  We are not looking for really close matches in this unit test, which is why
-        #  the tolerances are set rather large.  Really just a check that we are getting
-        #  some kind of reasonable value for the fit.  A more quantitative test may be needed.
+        # We are not looking for really close matches in this unit test,
+        # which is why the tolerances are set rather large.  Really just a
+        # check that we are getting some kind of reasonable value for the fit.
+        # A more quantitative test may be needed.
         self.assertFloatsAlmostEqual(flux0/flux1, 7.0/3.0, rtol=.05)
         self.assertFloatsAlmostEqual(comp0.getEllipse().getCore().getIxx(), 16.0, rtol=.05)
         self.assertFloatsAlmostEqual(comp0.getEllipse().getCore().getIyy(), 16.0, rtol=.05)

--- a/tests/test_emPsfApprox.py
+++ b/tests/test_emPsfApprox.py
@@ -192,12 +192,14 @@ class testEMTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(comp1.getEllipse().getCore().getIyy(), 100.0, rtol=.05)
         self.assertFloatsAlmostEqual(comp1.getEllipse().getCore().getIxy(), 0.0, atol=.1)
 
+
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
 def setup_module(module):
     lsst.utils.tests.init()
+
 
 if __name__ == "__main__":
     lsst.utils.tests.init()

--- a/tests/test_ngmix.py
+++ b/tests/test_ngmix.py
@@ -3,6 +3,7 @@ import unittest
 
 import lsst.utils.tests
 
+
 class NGMixTestCase(lsst.utils.tests.TestCase):
     """
     currently this just runs some tests on ngmix, and
@@ -13,20 +14,20 @@ class NGMixTestCase(lsst.utils.tests.TestCase):
     """
 
     def setUp(self):
-        self.T=4.0
-        self.counts=100.0
-        self.g1=0.1
-        self.g2=-0.05
+        self.T = 4.0
+        self.counts = 100.0
+        self.g1 = 0.1
+        self.g2 = -0.05
 
-        self.psf_model='gauss'
+        self.psf_model = 'gauss'
         self.g1psf = 0.03
         self.g2psf = -0.01
         self.Tpsf = 4.0
-        self.countspsf=1.0
-        self.noisepsf=0.001
+        self.countspsf = 1.0
+        self.noisepsf = 0.001
 
-        self.seed=100
-        self.rng=np.random.RandomState(self.seed)
+        self.seed = 100
+        self.rng = np.random.RandomState(self.seed)
 
     def testImports(self):
         """
@@ -34,20 +35,19 @@ class NGMixTestCase(lsst.utils.tests.TestCase):
         """
         try:
             import ngmix
-            ok=True
+            ok = True
         except:
-            ok=False
+            ok = False
 
-        self.assertEqual(ok,True)
+        self.assertEqual(ok, True)
 
         try:
             import lsst.meas.extensions.ngmix
-            ok=True
+            ok = True
         except:
-            ok=False
+            ok = False
 
-        self.assertEqual(ok,True)
-
+        self.assertEqual(ok, True)
 
     def testExp(self):
         """
@@ -55,27 +55,27 @@ class NGMixTestCase(lsst.utils.tests.TestCase):
         """
         import ngmix
 
-        rng=self.rng
+        rng = self.rng
 
         print('\n')
         for noise in [0.001, 0.1, 1.0]:
             print('='*10)
-            print('noise:',noise)
-            mdict=self._get_obs_data('exp',noise)
+            print('noise:', noise)
+            mdict = self._get_obs_data('exp', noise)
 
-            obs=mdict['obs']
+            obs = mdict['obs']
             obs.set_psf(mdict['psf_obs'])
 
-            pars=mdict['pars'].copy()
-            pars[0] += rng.uniform(low=-0.1,high=0.1)
-            pars[1] += rng.uniform(low=-0.1,high=0.1)
-            pars[2] += rng.uniform(low=-0.1,high=0.1)
-            pars[3] += rng.uniform(low=-0.1,high=0.1)
-            pars[4] *= (1.0 + rng.uniform(low=-0.1,high=0.1))
-            pars[5] *= (1.0 + rng.uniform(low=-0.1,high=0.1))
+            pars = mdict['pars'].copy()
+            pars[0] += rng.uniform(low=-0.1, high=0.1)
+            pars[1] += rng.uniform(low=-0.1, high=0.1)
+            pars[2] += rng.uniform(low=-0.1, high=0.1)
+            pars[3] += rng.uniform(low=-0.1, high=0.1)
+            pars[4] *= (1.0 + rng.uniform(low=-0.1, high=0.1))
+            pars[5] *= (1.0 + rng.uniform(low=-0.1, high=0.1))
 
-            max_pars={'method':'lm',
-                      'lm_pars':{'maxfev':4000}}
+            max_pars = {'method': 'lm',
+                        'lm_pars': {'maxfev': 4000}}
 
             cen_prior = ngmix.priors.CenPrior(0.0, 0.0, 0.2, 0.2)
             g_prior = ngmix.priors.GPriorBA(0.3)
@@ -83,22 +83,21 @@ class NGMixTestCase(lsst.utils.tests.TestCase):
             F_prior = ngmix.priors.FlatPrior(-0.97, 1.0e9)
 
             prior = ngmix.joint_prior.PriorSimpleSep(
-                 cen_prior,
-                 g_prior,
-                 T_prior,
-                 F_prior,
+                cen_prior,
+                g_prior,
+                T_prior,
+                F_prior,
             )
 
-            boot=ngmix.bootstrap.Bootstrapper(obs)
+            boot = ngmix.bootstrap.Bootstrapper(obs)
             boot.fit_psfs('gauss', 4.0)
             boot.fit_max('exp', max_pars, pars, prior=prior)
-            res=boot.get_max_fitter().get_result()
+            res = boot.get_max_fitter().get_result()
 
-            ngmix.print_pars(mdict['pars'],   front='pars true: ')
-            ngmix.print_pars(res['pars'],     front='pars meas: ')
+            ngmix.print_pars(mdict['pars'], front='pars true: ')
+            ngmix.print_pars(res['pars'], front='pars meas: ')
             ngmix.print_pars(res['pars_err'], front='pars err:  ')
-            print('s2n:',res['s2n_w'])
-
+            print('s2n:', res['s2n_w'])
 
     def testEM(self):
         import ngmix
@@ -106,19 +105,19 @@ class NGMixTestCase(lsst.utils.tests.TestCase):
         print('\n')
         for noise in [0.001]:
             print('='*10)
-            print('noise:',noise)
-            mdict=self._get_obs_data('exp',noise)
+            print('noise:', noise)
+            mdict = self._get_obs_data('exp', noise)
 
-            obs=mdict['obs']
-            
-            em_pars={
-                'maxiter':500,
-                'tol':1.0e-5,
+            obs = mdict['obs']
+
+            em_pars = {
+                'maxiter': 500,
+                'tol': 1.0e-5,
             }
-            for ngauss in [1,2,3,4]:
-                print('ngauss:',ngauss)
-                Tguess=4.0
-                runner=ngmix.bootstrap.EMRunner(
+            for ngauss in [1, 2, 3, 4]:
+                print('ngauss:', ngauss)
+                Tguess = 4.0
+                runner = ngmix.bootstrap.EMRunner(
                     obs,
                     Tguess,
                     ngauss,
@@ -126,47 +125,47 @@ class NGMixTestCase(lsst.utils.tests.TestCase):
                     rng=self.rng,
                 )
                 runner.go(ntry=2)
-                gm=runner.fitter.get_gmix()
+                gm = runner.fitter.get_gmix()
                 print(gm)
-                
+
     def _get_obs_data(self, model, noise):
         import ngmix
 
-        rng=self.rng
+        rng = self.rng
 
-        sigma=np.sqrt( (self.T + self.Tpsf)/2. )
-        dims=[2.*5.*sigma]*2
-        cen=[dims[0]/2., dims[1]/2.]
+        sigma = np.sqrt((self.T + self.Tpsf)/2.)
+        dims = [2.*5.*sigma]*2
+        cen = [dims[0]/2., dims[1]/2.]
 
-        j=ngmix.UnitJacobian(
+        j = ngmix.UnitJacobian(
             row=cen[0],
             col=cen[1],
         )
 
         pars_psf = [0.0, 0.0, self.g1psf, self.g2psf, self.Tpsf, self.countspsf]
-        gm_psf=ngmix.GMixModel(pars_psf, self.psf_model)
+        gm_psf = ngmix.GMixModel(pars_psf, self.psf_model)
 
         pars_obj = np.array([0.0, 0.0, self.g1, self.g2, self.T, self.counts])
-        npars=pars_obj.size
-        gm_obj0=ngmix.GMixModel(pars_obj, model)
+        npars = pars_obj.size
+        gm_obj0 = ngmix.GMixModel(pars_obj, model)
 
-        gm=gm_obj0.convolve(gm_psf)
+        gm = gm_obj0.convolve(gm_psf)
 
-        im_psf=gm_psf.make_image(dims, jacobian=j)
-        npsf=rng.normal(
+        im_psf = gm_psf.make_image(dims, jacobian=j)
+        npsf = rng.normal(
             scale=self.noisepsf,
             size=im_psf.shape,
         )
-        im_psf[:,:] += npsf
-        wt_psf=np.zeros(im_psf.shape) + 1./self.noisepsf**2
+        im_psf[:, :] += npsf
+        wt_psf = np.zeros(im_psf.shape) + 1./self.noisepsf**2
 
-        im_obj=gm.make_image(dims, jacobian=j)
-        n=rng.normal(
+        im_obj = gm.make_image(dims, jacobian=j)
+        n = rng.normal(
             scale=noise,
             size=im_obj.shape,
         )
-        im_obj[:,:] += n
-        wt_obj=np.zeros(im_obj.shape) + 1./noise**2
+        im_obj[:, :] += n
+        wt_obj = np.zeros(im_obj.shape) + 1./noise**2
 
         psf_obs = ngmix.Observation(
             im_psf,
@@ -174,16 +173,16 @@ class NGMixTestCase(lsst.utils.tests.TestCase):
             jacobian=j,
         )
 
-        obs=ngmix.Observation(
+        obs = ngmix.Observation(
             im_obj,
             weight=wt_obj,
             jacobian=j,
         )
 
         return {
-            'psf_obs':psf_obs,
-            'obs':obs,
-            'pars':pars_obj,
+            'psf_obs': psf_obs,
+            'obs': obs,
+            'pars': pars_obj,
         }
 
 

--- a/tests/test_ngmix.py
+++ b/tests/test_ngmix.py
@@ -146,7 +146,6 @@ class NGMixTestCase(lsst.utils.tests.TestCase):
         gm_psf = ngmix.GMixModel(pars_psf, self.psf_model)
 
         pars_obj = np.array([0.0, 0.0, self.g1, self.g2, self.T, self.counts])
-        npars = pars_obj.size
         gm_obj0 = ngmix.GMixModel(pars_obj, model)
 
         gm = gm_obj0.convolve(gm_psf)

--- a/tests/test_ngmix.py
+++ b/tests/test_ngmix.py
@@ -34,20 +34,20 @@ class NGMixTestCase(lsst.utils.tests.TestCase):
         try to import the primary code
         """
         try:
-            import ngmix
+            import ngmix  # noqa: F401
             ok = True
-        except:
+        except Exception:
             ok = False
 
-        self.assertEqual(ok, True)
+        self.assertTrue(ok)
 
         try:
-            import lsst.meas.extensions.ngmix
+            import lsst.meas.extensions.ngmix  # noqa: F401
             ok = True
-        except:
+        except Exception:
             ok = False
 
-        self.assertEqual(ok, True)
+        self.assertTrue(ok)
 
     def testExp(self):
         """


### PR DESCRIPTION
There are some oddities visible now that most of the flake8 warnings are gone:

```
./python/lsst/meas/extensions/ngmix/bootstrap.py:11:1: F401 'ngmix.gexceptions.GMixRangeError' imported but unused
./python/lsst/meas/extensions/ngmix/bootstrap.py:11:1: F401 'ngmix.gexceptions.BootPSFFailure' imported but unused
./python/lsst/meas/extensions/ngmix/bootstrap.py:11:1: F401 'ngmix.gexceptions.BootGalFailure' imported but unused
./python/lsst/meas/extensions/ngmix/bootstrap.py:418:13: F821 undefined name 'res'
./python/lsst/meas/extensions/ngmix/bootstrap.py:419:20: F821 undefined name 'res'
./python/lsst/meas/extensions/ngmix/mbobs_extractor.py:368:5: F841 local variable 'bits' is assigned to but never used
./python/lsst/meas/extensions/ngmix/priors.py:2:1: F401 'ngmix.joint_prior.PriorSimpleSep' imported but unused
./python/lsst/meas/extensions/ngmix/priors.py:2:1: F401 'ngmix.joint_prior.PriorBDFSep' imported but unused
./python/lsst/meas/extensions/ngmix/processCoaddsNGMix.py:776:13: F841 local variable 'model' is assigned to but never used
./python/lsst/meas/extensions/ngmix/processCoaddsNGMix.py:1095:9: F841 local variable 'front' is assigned to but never used
./python/lsst/meas/extensions/ngmix/processCoaddsNGMix.py:1166:13: F841 local variable 'model' is assigned to but never used
./tests/test_ngmix.py:149:9: F841 local variable 'npars' is assigned to but never used
```

I can  fix most of these by deleting them but the `res` variable one is vexing.